### PR TITLE
feat: Implement create-openapi Mojo to streamline REST API developmen…

### DIFF
--- a/examples/openapi.yaml
+++ b/examples/openapi.yaml
@@ -1,0 +1,238 @@
+openapi: 3.0.3
+info:
+  title: Product Management API
+  description: API for managing product operations with full CRUD functionality
+  version: 1.0.0
+  contact:
+    name: API Support Team
+    email: support@example.com
+
+servers:
+  - url: https://api.example.com/v1
+    description: Production server
+
+components:
+  schemas:
+    Product:
+      type: object
+      required:
+        - name
+        - price
+      properties:
+        id:
+          type: string
+          readOnly: true
+          description: Unique identifier for the product
+        name:
+          type: string
+          minLength: 2
+          maxLength: 100
+          description: Name of the product
+        description:
+          type: string
+          maxLength: 500
+          description: Detailed description of the product
+        price:
+          type: number
+          format: float
+          minimum: 0
+          description: Price of the product
+        category:
+          type: string
+          description: Product category
+        stock:
+          type: integer
+          minimum: 0
+          description: Current stock quantity
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Product creation timestamp
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Last update timestamp
+
+  parameters:
+    ProductId:
+      name: productId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Unique identifier of the product
+
+  responses:
+    BadRequest:
+      description: Bad request - Invalid input
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error message
+
+    NotFound:
+      description: Product not found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error message
+
+paths:
+  /products:
+    get:
+      summary: List all products
+      description: Retrieve a list of all products with optional filtering and pagination
+      operationId: listProducts
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+          description: Page number for pagination
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+          description: Number of products per page
+        - name: category
+          in: query
+          schema:
+            type: string
+          description: Filter products by category
+      responses:
+        '200':
+          description: Successful product list retrieval
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  products:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Product'
+                  total:
+                    type: integer
+                    description: Total number of products
+
+    post:
+      summary: Create a new product
+      description: Add a new product to the catalog
+      operationId: createProduct
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
+      responses:
+        '201':
+          description: Product successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /products/{productId}:
+    get:
+      summary: Get product details
+      description: Retrieve details of a specific product by ID
+      operationId: getProductById
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      responses:
+        '200':
+          description: Successful product retrieval
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      summary: Update a product
+      description: Update all details of an existing product
+      operationId: updateProduct
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
+      responses:
+        '200':
+          description: Product successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    patch:
+      summary: Partially update a product
+      description: Update specific fields of an existing product
+      operationId: partialUpdateProduct
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                price:
+                  type: number
+                  format: float
+                category:
+                  type: string
+                stock:
+                  type: integer
+      responses:
+        '200':
+          description: Product partially updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      summary: Delete a product
+      description: Remove a product from the catalog
+      operationId: deleteProduct
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      responses:
+        '204':
+          description: Product successfully deleted
+        '404':
+          $ref: '#/components/responses/NotFound'

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.9</maven.version>
         <maven.compiler.release>21</maven.compiler.release>
+        <mockito.version>5.17.0</mockito.version>
+        <org.slf4j-version>1.7.36</org.slf4j-version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -98,40 +100,63 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.4.2</version>
+            <version>5.4.3</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.9.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
-        <!--    <dependency>
-            <groupId>org.apache.maven.plugin-testing</groupId>
-            <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>3.3.0</version>
-            <scope>test</scope>
-        </dependency>-->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.18.0</version>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.14.2</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
-            <scope>test</scope>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${org.slf4j-version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.36</version>
-            <scope>test</scope>
+            <version>${org.slf4j-version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>openapi-generator-cli</artifactId>
+            <version>7.12.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -139,16 +164,15 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.4.1</version>
                 </plugin>
-                <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_maven-plugin_packaging -->
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
@@ -156,7 +180,13 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.5.3</version>
+                    <configuration>
+                        <argLine>
+                            -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+                            -Xshare:off
+                        </argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
@@ -164,11 +194,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.3</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.3</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-invoker-plugin</artifactId>
@@ -214,7 +244,7 @@
                         <configuration>
                             <postBuildHookScript>verify</postBuildHookScript>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-                            <settingsFile> ${base.pa} src/it/settings.xml</settingsFile>
+                            <settingsFile>${base.pa} src/it/settings.xml</settingsFile>
                             <goals>
                                 <goal>clean</goal>
                                 <goal>test-compile</goal>

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
@@ -342,7 +342,7 @@ public class JakartaEeHelper {
      * @throws IOException if an error occurs while adding the provider
      */
     public void addPersistenceClassProvider(MavenProject mavenProject, Log log) throws IOException {
-        var packageDefinition = MavenProjectHelper.getInstance().getProviderPackage(mavenProject);
+        var packageDefinition = MavenProjectHelper.getProviderPackage(mavenProject);
         var className = "PersistenceProvider";
         var persistenceProviderClassPath = PathsUtil.getJavaPath(mavenProject, packageDefinition, className);
         var annotationClasses = Map.of(

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaFacesHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaFacesHelper.java
@@ -107,7 +107,7 @@ public class JakartaFacesHelper {
      */
     public void createManagedBean(MavenProject mavenProject, Log log, String pageName) throws IOException {
         log.debug("Creating managed bean for " + pageName);
-        var packageDefinition = MavenProjectHelper.getInstance().getFacesPackage(mavenProject) ;
+        var packageDefinition = MavenProjectHelper.getFacesPackage(mavenProject) ;
         var className = StringsUtil.toPascalCase(pageName) + "Bean";
         var managedBean = PathsUtil.getJavaPath(mavenProject, packageDefinition, className);
         var annotationsClasses = Map.of(

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaPersistenceHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaPersistenceHelper.java
@@ -141,7 +141,7 @@ public class JakartaPersistenceHelper {
             var entityName = entity.getString(NAME);
             var tableName = entity.getString(TABLE_NAME, EMPTY);
             log.debug("Adding entity: " + entityName);
-            var packageDefinition = MavenProjectHelper.getInstance().getEntityPackage(mavenProject);
+            var packageDefinition = MavenProjectHelper.getEntityPackage(mavenProject);
             var entityPath = PathsUtil.getJavaPath(mavenProject, packageDefinition, entityName);
 
             var fieldsJson = entity.getJsonArray(FIELDS);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/MavenProjectHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/MavenProjectHelper.java
@@ -33,15 +33,6 @@ public class MavenProjectHelper {
     private MavenProjectHelper() {
     }
 
-    public static MavenProjectHelper getInstance() {
-        return MavenProjectUtilHolder.INSTANCE;
-    }
-
-    private static class MavenProjectUtilHolder {
-
-        private static final MavenProjectHelper INSTANCE = new MavenProjectHelper();
-    }
-
     /**
      * Retrieves the full Maven project with resolved dependencies.
      *
@@ -51,7 +42,7 @@ public class MavenProjectHelper {
      * @return the fully built Maven project with resolved dependencies
      * @throws ProjectBuildingException if an error occurs during project building
      */
-    public MavenProject getFullProject(MavenSession mavenSession,
+    public static MavenProject getFullProject(MavenSession mavenSession,
                                        ProjectBuilder projectBuilder,
                                        MavenProject mavenProject) throws ProjectBuildingException {
         var buildingRequest = mavenSession.getProjectBuildingRequest();
@@ -67,24 +58,28 @@ public class MavenProjectHelper {
      * @param mavenProject the Maven project containing the group ID and artifact ID
      * @return the generated package name as a string
      */
-    public String getProjectPackage(MavenProject mavenProject) {
+    public static String getProjectPackage(MavenProject mavenProject) {
         return "%s.%s".formatted(RegExUtils.replaceAll(mavenProject.getGroupId(), "[^a-zA-Z0-9]", "."),
             RegExUtils.replaceAll(mavenProject.getArtifactId(), "[^a-zA-Z0-9]", "."));
     }
 
-    public String getEntityPackage(MavenProject mavenProject) {
+    public static String getEntityPackage(MavenProject mavenProject) {
         return "%s.%s".formatted(getProjectPackage(mavenProject), "entity");
     }
 
-    public String getRepositoryPackage(MavenProject mavenProject) {
+    public static String getRepositoryPackage(MavenProject mavenProject) {
         return "%s.%s".formatted(getProjectPackage(mavenProject), "repository");
     }
 
-    public String getProviderPackage(MavenProject mavenProject) {
+    public static String getProviderPackage(MavenProject mavenProject) {
         return "%s.%s".formatted(getProjectPackage(mavenProject), "provider");
     }
 
-    public String getFacesPackage(MavenProject mavenProject) {
+    public static String getFacesPackage(MavenProject mavenProject) {
         return "%s.%s".formatted(getProjectPackage(mavenProject), "faces");
+    }
+
+    public static String getApiResourcesPackage(MavenProject mavenProject) {
+        return "%s.%s".formatted(getProjectPackage(mavenProject), "resources");
     }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/OpenApiGeneratorHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/OpenApiGeneratorHelper.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Diego Silva <diego.silva at apuntesdejava.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apuntesdejava.jakartacoffeebuilder.helper;
+
+import com.apuntesdejava.jakartacoffeebuilder.util.PathsUtil;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.openapitools.codegen.OpenAPIGenerator;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * @author Diego Silva <diego.silva at apuntesdejava.com>
+ */
+public class OpenApiGeneratorHelper {
+
+    public static OpenApiGeneratorHelper getInstance() {
+        return OpenApiGeneratorHelperHolder.INSTANCE;
+    }
+
+    private OpenApiGeneratorHelper() {
+    }
+
+    private Path getConfigPath(MavenProject mavenProject) throws URISyntaxException, IOException {
+        var apiResourcesPackage = MavenProjectHelper.getApiResourcesPackage(mavenProject);
+        var jsonFileContents = PathsUtil.getContentFromResource("openapi-generator/server-config.json")
+                                        .map(line -> line.replace("${packageResource}", apiResourcesPackage))
+                                        .toList();
+
+        var configTemp = Files.createTempFile("config-generator-coffee-builder", ".json");
+        Files.write(configTemp, jsonFileContents);
+        return configTemp;
+    }
+
+    /**
+     * Processes the OpenAPI file to generate code using the OpenAPI Generator Maven plugin.
+     *
+     * @param log          the Maven plugin logger to log messages
+     * @param mavenProject the Maven project containing the POM file
+     * @param openApiFile  the OpenAPI specification file to be processed
+     */
+    public void processServer(Log log,
+                              MavenProject mavenProject,
+                              File openApiFile) throws URISyntaxException, IOException {
+        var configTemp = getConfigPath(mavenProject);
+        OpenAPIGenerator.main(
+            new String[]{
+                "generate",
+                "--input-spec", openApiFile.getAbsolutePath(),
+                "--generator-name", "java-helidon-server",
+                "--output",
+                mavenProject.getBasedir().getAbsolutePath() + "/target/generated-sources/openapi",
+                "--config", configTemp.toAbsolutePath().toString()
+            }
+        );
+
+    }
+
+    private static class OpenApiGeneratorHelperHolder {
+
+        private static final OpenApiGeneratorHelper INSTANCE = new OpenApiGeneratorHelper();
+    }
+
+}

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceClassCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceClassCreator.java
@@ -37,7 +37,7 @@ public class DataSourceClassCreator extends DataSourceCreator {
 
     @Override
     public void build() throws IOException {
-        var packageDefinition = MavenProjectHelper.getInstance().getProviderPackage(mavenProject);
+        var packageDefinition = MavenProjectHelper.getProviderPackage(mavenProject);
         var className = "DataSourceProvider";
         var dataSourceClassPath = PathsUtil.getJavaPath(mavenProject, packageDefinition, className);
         var properties = getDataSourceParameters();

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/jakarta11/Jakarta11RepositoryBuilderImpl.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/jakarta11/Jakarta11RepositoryBuilderImpl.java
@@ -36,8 +36,8 @@ public class Jakarta11RepositoryBuilderImpl implements RepositoryBuilder {
         var entityName = getEntityName(entity);
         try {
             log.info("Building Jakarta 11 Repository for entity: " + entityName);
-            var packageDefinition = MavenProjectHelper.getInstance().getRepositoryPackage(mavenProject);
-            var packageEntity = MavenProjectHelper.getInstance().getEntityPackage(mavenProject);
+            var packageDefinition = MavenProjectHelper.getRepositoryPackage(mavenProject);
+            var packageEntity = MavenProjectHelper.getEntityPackage(mavenProject);
             var className = entityName + "Repository";
             var fieldId = getFieldId(entity);
             var repositoryPath = PathsUtil.getJavaPath(mavenProject, packageDefinition, className);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojo.java
@@ -133,8 +133,7 @@ public class AddFacesMojo extends AbstractMojo {
     private void checkDependency(Log log) throws MojoExecutionException {
         log.debug("checking Jakarta Faces dependency");
         try {
-            var fullProject = MavenProjectHelper.getInstance()
-                                                .getFullProject(mavenSession, projectBuilder, mavenProject);
+            var fullProject = MavenProjectHelper.getFullProject(mavenSession, projectBuilder, mavenProject);
 
             var jakartaEeUtil = JakartaEeHelper.getInstance();
             if (!jakartaEeUtil.hasJakartaFacesDependency(fullProject, log)) {

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojo.java
@@ -79,8 +79,7 @@ public class AddPersistenceMojo extends AbstractMojo {
     private void checkDependency(Log log) throws MojoExecutionException {
         log.debug("checking Jakarta Persistence dependency");
         try {
-            var fullProject = MavenProjectHelper.getInstance()
-                                                .getFullProject(mavenSession, projectBuilder, mavenProject);
+            var fullProject = MavenProjectHelper.getFullProject(mavenSession, projectBuilder, mavenProject);
             var jakartaEeHelper = JakartaEeHelper.getInstance();
             if (jakartaEeHelper.hasNotJakartaCdiDependency(fullProject, log))
                 jakartaEeHelper.addJakartaCdiDependency(mavenProject, log, jakartaEeVersion);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Diego Silva <diego.silva at apuntesdejava.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apuntesdejava.jakartacoffeebuilder.mojo.rest;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.OpenApiGeneratorHelper;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+@Mojo(
+    name = "create-openapi"
+)
+public class CreateOpenApiMojo extends AbstractMojo {
+
+    @Parameter(
+        property = "openapi-server",
+        required = true,
+        defaultValue = "${project.basedir}/openapi.yml"
+    )
+    private File openApiFileServer;
+
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject mavenProject;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        var log = getLog();
+        Optional.ofNullable(openApiFileServer).ifPresent(openApiFile -> {
+            log.info("Creating open api server side with %s".formatted(openApiFile));
+            try {
+                OpenApiGeneratorHelper.getInstance().processServer(log, mavenProject, openApiFile);
+            } catch (URISyntaxException | IOException e) {
+                throw new RuntimeException(new MojoFailureException(e));
+            }
+
+        });
+    }
+}

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/PathsUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/PathsUtil.java
@@ -15,12 +15,16 @@
  */
 package com.apuntesdejava.jakartacoffeebuilder.util;
 
-import com.apuntesdejava.jakartacoffeebuilder.helper.MavenProjectHelper;
 import org.apache.maven.project.MavenProject;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.IOUtils;
 
 /**
  * Utility class for working with file paths within a Maven project. Provides methods for obtaining paths to common
@@ -66,7 +70,7 @@ public class PathsUtil {
      * Returns the path to a package directory within the specified base directory. Creates the directory if it doesn't
      * exist. The package name is converted to a path using '/' as a separator.
      *
-     * @param javaDir     The base directory.
+     * @param javaDir The base directory.
      * @param packageName The package name (e.g., "com.example.mypackage").
      * @return The Path object representing the package directory.
      * @throws IOException If an I/O error occurs during directory creation.
@@ -83,8 +87,8 @@ public class PathsUtil {
      * Returns the path to a Java source file within a specified package directory within the Maven project. Creates
      * necessary directories if they don't exist.
      *
-     * @param mavenProject   The Maven project object.
-     * @param javaClassName  The name of the Java class (without the .java extension).
+     * @param mavenProject The Maven project object.
+     * @param javaClassName The name of the Java class (without the .java extension).
      * @return The Path object representing the Java source file.
      * @throws IOException If an I/O error occurs during directory creation.
      */
@@ -94,5 +98,11 @@ public class PathsUtil {
         var javaDir = PathsUtil.getJavaPath(mavenProject);
         var packageDir = PathsUtil.packageToPath(javaDir, packageDefinition);
         return packageDir.resolve(javaClassName + ".java");
+    }
+
+    public static Stream<String> getContentFromResource(String resourcePath) throws IOException {
+        try (var is = PathsUtil.class.getClassLoader().getResourceAsStream(resourcePath)) {
+           return IOUtils.toString(Objects.requireNonNull(is), Charset.defaultCharset()).lines();
+        }
     }
 }

--- a/src/main/resources/openapi-generator/server-config.json
+++ b/src/main/resources/openapi-generator/server-config.json
@@ -1,0 +1,16 @@
+{
+  "generatorName": "java-helidon-server",
+  "generateModelTests": "false",
+  "generateModelDocumentation": "false",
+  "generateApiDocumentation": "false",
+  "generateApiTests": "false",
+  "configOptions": {
+    "fullProject": "false",
+    "library": "mp",
+    "sourceFolder": "src/java/main",
+    "useJakartaEe": "true",
+    "serializationLibrary": "jsonb",
+    "modelPackage": "${packageResource}.model",
+    "apiPackage": "${packageResource}.api"
+  }
+}


### PR DESCRIPTION
…t from OpenAPI specifications

This commit introduces a new Maven Mojo, create-openapi, which enables developers to generate REST API endpoints directly from an OpenAPI specification (e.g., openapi.yaml). This promotes a design-first approach to API development, ensuring consistency and reducing development time. Includes an example openapi.yaml for Product Management. Also refactors existing helper classes to use static methods.