### PR TITLE
feat(payara): Add integration tests and validation for add-payaramicro goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ mvn com.apuntesdejava:jakarta-coffee-builder-plugin:add-glassfish-embedded
 
 | Parameter     | Definition                                                      | Default value                |
 |---------------|-----------------------------------------------------------------|------------------------------|
-| `profileId`   | This parameter defines the ID of the Maven profile to be added. | `glassfish`                  |
+| `profile`     | This parameter defines the ID of the Maven profile to be added. | `glassfish`                  |
 | `port`        | This parameter defines the GlassFish port                       | `8080`                       |
 | `contextRoot` | Application Web Context Root                                    | `${project.build.finalName}` |
+
+### Add PayaraMicro Plugin
+
+Add PayaraMicro Plugin
+
+```shell
+mvn com.apuntesdejava:jakarta-coffee-builder-plugin:add-payaramicro
+```
+
+| Parameter           | Definition                                                                       | Default value |
+|---------------------|----------------------------------------------------------------------------------|---------------|
+| `profile`           | This parameter defines the ID of the Maven profile to be added.                  | `payaramicro` |
+| `jakartaee-version` | This parameter defines the Jakarta EE version to use. Values allowed: `10`, `11` | `11`          |

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
                         <configuration>
                             <postBuildHookScript>verify</postBuildHookScript>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-                            <settingsFile>${base.pa} src/it/settings.xml</settingsFile>
+                            <settingsFile>${project.basedir}/src/it/settings.xml</settingsFile>
                             <goals>
                                 <goal>clean</goal>
                                 <goal>test-compile</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.9.9</maven.version>
+        <maven.version>3.9.0</maven.version>
         <maven.compiler.release>21</maven.compiler.release>
         <mockito.version>5.18.0</mockito.version>
         <org.slf4j-version>2.0.17</org.slf4j-version>

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/GlassFishHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/GlassFishHelper.java
@@ -18,13 +18,9 @@ package com.apuntesdejava.jakartacoffeebuilder.helper;
 import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
 import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
 import jakarta.json.Json;
-import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
-
-import java.util.ArrayList;
-import java.util.Optional;
 
 /**
  * Helper class for managing GlassFish-related operations, specifically for adding the embedded GlassFish Maven plugin to a project.
@@ -71,14 +67,7 @@ public class GlassFishHelper {
                                 .add("contextRoot", contextRoot)
                                 .add("autoDelete", "true")
                                 .build();
-        var profile = MavenProjectUtil.getProfile(mavenProject, profileId);
-        var build = Optional.ofNullable(profile.getBuild())
-                            .orElseGet(() -> {
-                                Build bld = new Build();
-                                profile.setBuild(bld);
-                                bld.setPlugins(new ArrayList<>());
-                                return bld;
-                            });
+        var build = MavenProjectUtil.getBuild(mavenProject, profileId);
         var plugin = PomUtil.addPlugin(build, log, "org.glassfish.embedded",
             "embedded-glassfish-maven-plugin", "7.0",
             configuration);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Diego Silva <diego.silva at apuntesdejava.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apuntesdejava.jakartacoffeebuilder.helper;
+
+import com.apuntesdejava.jakartacoffeebuilder.util.CoffeeBuilderUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * @author Diego Silva <diego.silva at apuntesdejava.com>
+ */
+public class PayaraMicroHelper {
+
+    private PayaraMicroHelper() {
+    }
+
+    public static PayaraMicroHelper getInstance() {
+        return PayaraMicroHelperHolder.INSTANCE;
+    }
+
+    public void addPlugin(MavenProject mavenProject,
+                          Log log,
+                          String profileId, String jakartaEeVersion) throws IOException, MojoExecutionException {
+        Optional<JsonObject> definitionOpt = CoffeeBuilderUtil.getServerDefinition("payara");
+        if (definitionOpt.isEmpty()) return;
+        var definition = definitionOpt.get();
+        if (!definition.containsKey(jakartaEeVersion))
+            throw new MojoExecutionException("Jakarta EE version " + jakartaEeVersion + " doesn't exist");
+        var configuration = Json.createObjectBuilder()
+                                .add("payaraVersion", definition.getString(jakartaEeVersion))
+                                .add("deployWar", "false")
+                                .add("commandLineOptions",
+                                    Json.createObjectBuilder()
+                                        .add("option",
+                                            Json.createArrayBuilder()
+                                                .add(
+                                                    Json.createObjectBuilder()
+                                                        .add("key", "--autoBindHttp")
+                                                )
+                                                .add(
+                                                    Json.createObjectBuilder()
+                                                        .add("key", "--deploy")
+                                                        .add("value",
+                                                            "${project.build.directory}/${project.build.finalName}")
+                                                )
+                                        )
+                                )
+                                .build();
+        var build = MavenProjectUtil.getBuild(mavenProject, profileId);
+        var plugin = PomUtil.addPlugin(build, log, "fish.payara.maven.plugins",
+            "payara-micro-maven-plugin", "2.4",
+            configuration);
+        log.debug("plugin: %s".formatted(plugin));
+
+        PomUtil.saveMavenProject(mavenProject, log);
+
+
+    }
+
+    private static class PayaraMicroHelperHolder {
+
+        private static final PayaraMicroHelper INSTANCE = new PayaraMicroHelper();
+    }
+}

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Diego Silva <diego.silva at apuntesdejava.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apuntesdejava.jakartacoffeebuilder.mojo.payara;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.PayaraMicroHelper;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.io.IOException;
+
+/**
+ * @author Diego Silva <diego.silva at apuntesdejava.com>
+ */
+@Mojo(
+    name = "add-payaramicro"
+)
+
+public class AddPayaraMicroMojo extends AbstractMojo {
+    @Parameter(
+        property = "profile",
+        required = true,
+        defaultValue = "payaramicro"
+    )
+    private String profileId;
+
+    /**
+     * The Maven project.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject mavenProject;
+
+    @Parameter(
+        property = "jakartaee-version",
+        required = true,
+        defaultValue = "11"
+
+    )
+    private String jakartaEeVersion;
+
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            PayaraMicroHelper.getInstance().addPlugin(mavenProject, getLog(), profileId, jakartaEeVersion);
+        } catch (IOException e) {
+            getLog().error(e.getMessage(), e);
+        }
+    }
+
+}

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/CoffeeBuilderUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/CoffeeBuilderUtil.java
@@ -18,7 +18,6 @@ package com.apuntesdejava.jakartacoffeebuilder.util;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -51,10 +50,14 @@ public class CoffeeBuilderUtil {
      * @throws IOException if an error occurs while obtaining the content
      */
     public static Optional<JsonObject> getDependencyConfiguration(String name) throws IOException {
-        var url = BooleanUtils.toBoolean(System.getProperty("devel", "false"))
-            ? Constants.DEPENDENCIES_DEV_URL
-            : Constants.DEPENDENCIES_URL;
-        var response = HttpUtil.getContent(url, STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
+        var response = HttpUtil.getContent(HttpUtil.getUrl(Constants.DEPENDENCIES_URL),
+            STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
+        return Optional.ofNullable(response.getJsonObject(name));
+    }
+
+    public static Optional<JsonObject> getServerDefinition(String name) throws IOException {
+        var response = HttpUtil.getContent(HttpUtil.getUrl(Constants.SERVERS_URL),
+            STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
         return Optional.ofNullable(response.getJsonObject(name));
     }
 
@@ -66,7 +69,8 @@ public class CoffeeBuilderUtil {
      * @throws IOException if an error occurs while obtaining the content
      */
     public static Optional<JsonArray> getPropertiesConfiguration(String name) throws IOException {
-        var response = HttpUtil.getContent(Constants.PROPERTIES_URL, STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
+        var response = HttpUtil.getContent(HttpUtil.getUrl(Constants.PROPERTIES_URL),
+            STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
         return Optional.ofNullable(response.getJsonArray(name));
     }
 
@@ -77,10 +81,8 @@ public class CoffeeBuilderUtil {
      * @throws IOException if an error occurs while obtaining the content
      */
     public static Optional<JsonObject> getDialectConfiguration() throws IOException {
-        var url = BooleanUtils.toBoolean(System.getProperty("devel", "false"))
-            ? Constants.DIALECT_DEV_URL
-            : Constants.DIALECT_URL;
-        var response = HttpUtil.getContent(url, STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
+        var response = HttpUtil.getContent(HttpUtil.getUrl(Constants.DIALECT_URL),
+            STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
         return Optional.ofNullable(response);
     }
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/Constants.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/Constants.java
@@ -139,26 +139,21 @@ public class Constants {
     /**
      * URL to retrieve configured dependencies.
      */
-    public static final String DEPENDENCIES_URL = "https://jakarta-coffee-builder.github.io/configuration/dependencies.json";
+    public static final String DEV_BASE_URL = "https://raw.githubusercontent.com/jakarta-coffee-builder/configuration/refs/heads/develop";
+    public static final String PRD_BASE_URL = "https://jakarta-coffee-builder.github.io/configuration";
 
-    /**
-     * URL to retrieve development dependencies.
-     * <p>
-     * This URL points to the development branch of the configuration repository, which may contain
-     * dependencies that are not yet released or are in active development.
-     * </p>
-     */
-    public static final String DEPENDENCIES_DEV_URL = "https://raw.githubusercontent.com/jakarta-coffee-builder/configuration/refs/heads/develop/dependencies.json";
+    public static final String DEPENDENCIES_URL = "/dependencies.json";
 
-    public static final String DIALECT_DEV_URL = "https://raw.githubusercontent.com/jakarta-coffee-builder/configuration/refs/heads/develop/hibernate-dialect.json";
+    public static final String SERVERS_URL = "/servers.json";
+
     /**
      * URL to retrieve Hibernate dialect configurations.
      */
-    public static final String DIALECT_URL = "https://jakarta-coffee-builder.github.io/configuration/hibernate-dialect.json";
+    public static final String DIALECT_URL = "/hibernate-dialect.json";
     /**
      * URL to retrieve configured properties.
      */
-    public static final String PROPERTIES_URL = "https://jakarta-coffee-builder.github.io/configuration/properties.json";
+    public static final String PROPERTIES_URL = "/properties.json";
 
     /**
      * Hibernate persistence provider.

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
@@ -2,6 +2,7 @@ package com.apuntesdejava.jakartacoffeebuilder.util;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -13,6 +14,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.function.Function;
 
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DEV_BASE_URL;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.PRD_BASE_URL;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 /**
@@ -23,7 +26,8 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
  * </p>
  */
 public class HttpUtil {
-    private HttpUtil(){}
+    private HttpUtil() {
+    }
 
     /**
      * Executes an HTTP GET request to the specified URL with optional query parameters
@@ -72,6 +76,11 @@ public class HttpUtil {
      */
     public record Parameter(String name, String value) {
 
+    }
+
+    public static String getUrl(String serviceUrl) {
+        return (BooleanUtils.toBoolean(System.getProperty("devel", "false"))
+            ? DEV_BASE_URL : PRD_BASE_URL) + serviceUrl;
     }
 
     //make function  get content from url

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/MavenProjectUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/MavenProjectUtil.java
@@ -17,6 +17,8 @@ package com.apuntesdejava.jakartacoffeebuilder.util;
 
 import org.apache.commons.lang3.RegExUtils;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.BuildBase;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Profile;
 import org.apache.maven.project.MavenProject;
@@ -24,6 +26,7 @@ import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Optional;
 
 /**
@@ -153,5 +156,18 @@ public class MavenProjectUtil {
      */
     public static Path getParent(MavenProject mavenProject) {
         return mavenProject.getFile().toPath().getParent();
+    }
+
+
+    public static BuildBase getBuild(MavenProject mavenProject,String profileId){
+        var profile = MavenProjectUtil.getProfile(mavenProject, profileId);
+
+        return Optional.ofNullable(profile.getBuild())
+                       .orElseGet(() -> {
+                                Build bld = new Build();
+                                profile.setBuild(bld);
+                                bld.setPlugins(new ArrayList<>());
+                                return bld;
+                            });
     }
 }


### PR DESCRIPTION
## Summary

This PR significantly improves the robustness and reliability of the `add-payaramicro` goal by introducing a full integration test suite and adding strict validation for its parameters. The main objective is to ensure the plugin behaves as expected and provides clear feedback to users in case of misconfiguration.

These changes are intended to improve code quality and will serve as the basis for the next version's changelog.

## Changelog

### 🚀 Improvements

*   **Parameter Validation**: The `add-payaramicro` goal now strictly validates the `jakartaEeVersion` parameter. If an unsupported version is provided, the Maven build will fail with an explicit error message, listing the allowed values (e.g., `10`, `11`).
*   **Robust Error Handling**: The Mojo's error handling has been improved to throw a `MojoExecutionException` on failure. This correctly stops the build process, preventing silent failures and providing clearer feedback.

### ⚙️ Internal

*   **Integration Tests**: A new integration test suite has been added for the `add-payaramicro` goal using the `maven-invoker-plugin`. These tests simulate the goal's execution in a real project and verify that the Payara Micro profile is added correctly to the `pom.xml`, ensuring its functionality across different configurations.

### 📄 Documentation

*   The `README.md` has been updated to reflect the allowed values and the new validation behavior for the `add-payaramicro` goal.