### PR TITLE
feat(build): Introduce Payara Micro integration support

### DIFF
--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
@@ -432,18 +432,19 @@ public class JakartaEeHelper {
      * Adds the Jakarta Validation API dependency to the Maven project. This method retrieves the version from the
      * configuration and sets the "jakarta.validation-api.version" property in the pom.xml.
      *
-     * @param mavenProject The Maven project to modify.
-     * @param log          The logger for logging messages.
+     * @param mavenProject     The Maven project to modify.
+     * @param log              The logger for logging messages.
+     * @param jakartaEeVersion The version of Jakarta EE to use for the dependency.
      * @throws IOException            If an I/O error occurs.
      * @throws MojoExecutionException If a Maven execution error occurs.
      */
     public void addJakartaValidationApiDependency(MavenProject mavenProject,
-                                                  Log log) throws IOException, MojoExecutionException {
-        CoffeeBuilderUtil.getDependencyConfiguration("jakarta.validation-api-11.0.0")
-                         .ifPresent(
-                             openApi -> PomUtil
-                                 .setProperty(mavenProject, log, "jakarta.validation-api.version",
-                                     openApi.getString("version")));
+                                                  Log log,
+                                                  String jakartaEeVersion) throws IOException, MojoExecutionException {
+        var openApi = CoffeeBuilderUtil.getDependencyConfiguration("jakarta.validation-api-" + jakartaEeVersion)
+                                       .orElseThrow(() -> new MojoExecutionException("Dependency not found"));
+        PomUtil.setProperty(mavenProject, log, "jakarta.validation-api.version",
+            openApi.getString("version"));
         PomUtil.addDependency(mavenProject, log, "jakarta.validation", "jakarta.validation-api",
             "${jakarta.validation-api.version}", "provided");
         PomUtil.saveMavenProject(mavenProject, log);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
@@ -39,6 +39,16 @@ public class PayaraMicroHelper {
         return PayaraMicroHelperHolder.INSTANCE;
     }
 
+    /**
+     * Adds the Payara Micro Maven plugin to the project's POM file.
+     *
+     * @param mavenProject The Maven project.
+     * @param log The Maven logger.
+     * @param profileId The ID of the profile to which the plugin should be added.
+     * @param jakartaEeVersion The Jakarta EE version to be used with Payara Micro.
+     * @throws IOException If an I/O error occurs while reading or writing the POM.
+     * @throws MojoExecutionException If an error occurs during plugin execution.
+     */
     public void addPlugin(MavenProject mavenProject,
                           Log log,
                           String profileId, String jakartaEeVersion) throws IOException, MojoExecutionException {

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojo.java
@@ -1,0 +1,49 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.jakartaee;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.io.IOException;
+
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.JAKARTAEE_VERSION_11;
+
+@Mojo(
+    name = "add-validation-api"
+)
+public class AddValidationApiMojo extends AbstractMojo {
+    /**
+     * The Maven project.
+     */
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject mavenProject;
+
+    @Parameter(
+        property = "jakartaee-version",
+        required = true,
+        defaultValue = JAKARTAEE_VERSION_11
+
+    )
+    private String jakartaEeVersion;
+
+    /**
+     * Constructor por defecto.
+     */
+    public AddValidationApiMojo() {
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        var log = getLog();
+        var jakartaEeHelper = JakartaEeHelper.getInstance();
+        try {
+            jakartaEeHelper.addJakartaValidationApiDependency(mavenProject, log, jakartaEeVersion);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojo.java
@@ -25,6 +25,8 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.IOException;
 
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.JAKARTAEE_VERSION_11;
+
 /**
  * @author Diego Silva <diego.silva at apuntesdejava.com>
  */
@@ -49,7 +51,7 @@ public class AddPayaraMicroMojo extends AbstractMojo {
     @Parameter(
         property = "jakartaee-version",
         required = true,
-        defaultValue = "11"
+        defaultValue = JAKARTAEE_VERSION_11
 
     )
     private String jakartaEeVersion;

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Optional;
 
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.JAKARTAEE_VERSION_11;
+
 /**
  * Mojo for generating server-side OpenAPI files.
  * <p>
@@ -78,6 +80,14 @@ public class CreateOpenApiMojo extends AbstractMojo {
     )
     private File openApiFileServer;
 
+    @Parameter(
+        property = "jakartaee-version",
+        required = true,
+        defaultValue = JAKARTAEE_VERSION_11
+
+    )
+    private String jakartaEeVersion;
+
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject mavenProject;
 
@@ -108,7 +118,7 @@ public class CreateOpenApiMojo extends AbstractMojo {
         try {
             jakartaEeHelper.addJacksonDependency(mavenProject, log);
             jakartaEeHelper.addMicroprofileOpenApiApiDependency(mavenProject, log);
-            jakartaEeHelper.addJakartaValidationApiDependency(mavenProject, log);
+            jakartaEeHelper.addJakartaValidationApiDependency(mavenProject, log, jakartaEeVersion);
 
             Optional.ofNullable(openApiFileServer).ifPresent(openApiFile -> {
                 log.info("Creating open api server side with %s".formatted(openApiFile));


### PR DESCRIPTION
# PR: feat: Add Payara Micro support and enhance OpenAPI & Data configuration

This pull request introduces significant new features and improvements to the plugin. It adds support for automatically configuring the Payara Micro Maven plugin, enhances the OpenAPI generation by adding necessary dependencies, and improves the data layer setup by including automatic JPA Metamodel generation.

Additionally, dependency version management has been centralized and made dynamic by fetching configurations from a remote source, making the plugin more robust and easier to maintain.

## Changelog

### ✨ New Features

#### 1. Payara Micro Integration
A new goal has been added to seamlessly integrate Payara Micro into a project.

*   **New Mojo:** `jakarta-coffee-builder:add-payaramicro`
*   **Functionality:** Automatically configures the `payara-micro-maven-plugin` in the `pom.xml` within a specified profile.
*   **Dynamic Configuration:** The Payara Micro version is dynamically resolved based on the selected Jakarta EE version, fetching the mapping from a remote configuration file.

*Example Mojo Execution:*