### PR TITLE
refactor: Update ManagedBean template to use repository classes

### DIFF
--- a/src/main/resources/freemaker/java/ManagedBeanCrud.ftl
+++ b/src/main/resources/freemaker/java/ManagedBeanCrud.ftl
@@ -6,8 +6,8 @@ import ${importItem};
     </#list>
 </#if>
 <#assign formId="${instanceModelName}Form" />
-<#assign serviceClassName="${modelName}Service" />
-<#assign serviceInstanceName="${instanceModelName}Service" />
+<#assign serviceClassName="${modelName}Repository" />
+<#assign serviceInstanceName="${instanceModelName}Repository" />
 <#assign currentModel="current${modelName}" />
 <#assign selectedModels="selected${modelName}s" />
 <#assign idNameCap=idName?cap_first />


### PR DESCRIPTION
- Replaced service class (`${modelName}Service`) with repository class (`${modelName}Repository`) in `ManagedBeanCrud.ftl`.
- Updated service instance name accordingly to align with repository naming convention.