### PR TITLE
Add database action property to PersistenceXmlHelper

### DIFF
--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PersistenceXmlHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PersistenceXmlHelper.java
@@ -26,6 +26,7 @@ import org.dom4j.Namespace;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
@@ -88,6 +89,11 @@ public class PersistenceXmlHelper {
                 persistenceElem.addAttribute("version", schemaDescription.getString("version"));
 
                 var persistenceUnitElem = xmlUtil.addElement(persistenceElem, "persistence-unit");
+                var propertiesElement = xmlUtil.addElement(persistenceUnitElem, "properties");
+                xmlUtil.addElement(propertiesElement, "property", Map.of(
+                    "name", "jakarta.persistence.schema-generation.database.action",
+                    "value", "drop-and-create"
+                ));
                 persistenceUnitElem.addAttribute(NAME, persistenceUnitName);
             } catch (IOException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
 
### Description of changes

This pull request introduces the following changes:

- Adds a "properties" element under "persistence-unit" within `PersistenceXmlHelper` to support additional Jakarta persistence configurations.
- Incorporates the property `jakarta.persistence.schema-generation.database.action` with a value of `drop-and-create` for schema management.
- Updates XML generation logic to dynamically reflect the inclusion of the new property.
- Enhances error handling with a `RuntimeException` for IO-related scenarios.

### Checklist

- [ ] Tests added for new functionality
- [ ] Documentation updated if applicable
- [ ] Changes meet project coding guidelines 