### PR TITLE
feat: Introduce AbstractModelRepository interface and integrate into …

### DIFF
--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/ArchitectureHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/ArchitectureHelper.java
@@ -237,7 +237,7 @@ public class ArchitectureHelper {
             );
 
             importsList.addAll(List.of(
-                MavenProjectUtil.getModelRepositoryPackage(mavenProject)+ "." + modelName + "Repository",
+                MavenProjectUtil.getModelRepositoryPackage(mavenProject) + "." + modelName + "Repository",
                 MavenProjectUtil.getMapperPackage(mavenProject) + "." + modelName + "Mapper",
                 MavenProjectUtil.getModelPackage(mavenProject) + "." + modelName,
                 MavenProjectUtil.getRepositoryPackage(mavenProject) + "." + modelName + "EntityRepository"
@@ -257,10 +257,27 @@ public class ArchitectureHelper {
     }
 
     public void createModelRepositoryInterfaces(MavenProject mavenProject, Log log, JsonObject jsonContent) {
+        createAbstractModelRepositoryInterface(mavenProject, log);
         jsonContent.forEach((entityName, entityDefinition) -> createModelRepositoryInterface(mavenProject,
             log,
             entityName,
             entityDefinition));
+    }
+
+    private void createAbstractModelRepositoryInterface(MavenProject mavenProject, Log log) {
+        try {
+            var packageDefinition = MavenProjectUtil.getModelRepositoryPackage(mavenProject);
+            var abstractModelRepositoryPath = PathsUtil.getJavaPath(mavenProject,
+                packageDefinition,
+                "AbstractModelRepository");
+
+            var fieldsMap = Map.ofEntries(
+                Map.entry(PACKAGE_NAME, (Object) packageDefinition)
+            );
+            TemplateUtil.getInstance().createAbstractModelRepositoryFile(log, fieldsMap, abstractModelRepositoryPath);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
     }
 
     private void createModelRepositoryInterface(MavenProject mavenProject,

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/TemplateUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/TemplateUtil.java
@@ -58,8 +58,8 @@ public class TemplateUtil {
     /**
      * <p>Generates a Java Bean file using a template and writes it to the specified file path.</p>
      *
-     * @param log The logger used to log messages and errors.
-     * @param data The data model map containing values to populate the Java Bean template.
+     * @param log      The logger used to log messages and errors.
+     * @param data     The data model map containing values to populate the Java Bean template.
      * @param javaPath The file path where the generated Java Bean will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
@@ -74,8 +74,8 @@ public class TemplateUtil {
     /**
      * Generates an Entity file using a template and writes it to the specified file path.
      *
-     * @param log The logger used to log messages and errors.
-     * @param data The data model map containing values to populate the Entity template.
+     * @param log      The logger used to log messages and errors.
+     * @param data     The data model map containing values to populate the Entity template.
      * @param javaPath The file path where the generated Entity file will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
@@ -86,8 +86,8 @@ public class TemplateUtil {
     /**
      * Generates a Repository file using a template and writes it to the specified file path.
      *
-     * @param log The logger used to log messages and errors.
-     * @param data The data model map containing values to populate the Repository template.
+     * @param log      The logger used to log messages and errors.
+     * @param data     The data model map containing values to populate the Repository template.
      * @param javaPath The file path where the generated Repository file will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
@@ -101,9 +101,10 @@ public class TemplateUtil {
      * <p>
      * This is a generic method used by other `create*File` methods to handle the common logic
      * of loading a Freemarker template, processing it with provided data, and writing the output to a file.</p>
-     * @param log The logger for reporting errors.
-     * @param data The data model to be used by the Freemarker template.
-     * @param javaPath The path where the generated Java file will be written.
+     *
+     * @param log          The logger for reporting errors.
+     * @param data         The data model to be used by the Freemarker template.
+     * @param javaPath     The path where the generated Java file will be written.
      * @param templateName The name of the Freemarker template to use (e.g., "java/JavaBean.ftl").
      * @throws IOException If an I/O error occurs during file operations.
      */
@@ -123,8 +124,8 @@ public class TemplateUtil {
     /**
      * Generates an Enum file using a template and writes it to the specified file path.
      *
-     * @param log The logger used to log messages and errors.
-     * @param data The data model map containing values to populate the Enum template.
+     * @param log      The logger used to log messages and errors.
+     * @param data     The data model map containing values to populate the Enum template.
      * @param enumPath The file path where the generated Enum file will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
@@ -135,8 +136,8 @@ public class TemplateUtil {
     /**
      * Generates a Mapper file using a template and writes it to the specified file path.
      *
-     * @param log The logger used to log messages and errors.
-     * @param data The data model map containing values to populate the Mapper template.
+     * @param log        The logger used to log messages and errors.
+     * @param data       The data model map containing values to populate the Mapper template.
      * @param mapperPath The file path where the generated Mapper file will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
@@ -147,8 +148,8 @@ public class TemplateUtil {
     /**
      * Generates a Service file using a template and writes it to the specified file path.
      *
-     * @param log The logger used to log messages and errors.
-     * @param data The data model map containing values to populate the Service template.
+     * @param log         The logger used to log messages and errors.
+     * @param data        The data model map containing values to populate the Service template.
      * @param servicePath The file path where the generated Service file will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
@@ -160,12 +161,16 @@ public class TemplateUtil {
         createJavaFile(log, data, servicePath, "java/ModelRepository.ftl");
     }
 
+    public void createAbstractModelRepositoryFile(Log log, Map<String, Object> data, Path servicePath) throws
+        IOException {
+        createJavaFile(log, data, servicePath, "java/AbstractModelRepository.ftl");
+    }
 
     /**
      * Generates a Plain Old Java Object (POJO) file using a template and writes it to the specified file path.
      *
-     * @param log The logger used to log messages and errors.
-     * @param data The data model map containing values to populate the POJO template.
+     * @param log      The logger used to log messages and errors.
+     * @param data     The data model map containing values to populate the POJO template.
      * @param pojoPath The file path where the generated POJO file will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
@@ -176,8 +181,8 @@ public class TemplateUtil {
     /**
      * Generates a JavaServer Faces (JSF) template file (XHTML) using a template and writes it to the specified file path.
      *
-     * @param log The logger used to log messages and errors.
-     * @param data The data model map containing values to populate the JSF template.
+     * @param log       The logger used to log messages and errors.
+     * @param data      The data model map containing values to populate the JSF template.
      * @param xhtmlPath The file path where the generated XHTML file will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
@@ -189,21 +194,22 @@ public class TemplateUtil {
      * Generates a JavaServer Faces (JSF) CRUD (Create, Read, Update, Delete) file (XHTML) using a template and writes it to the specified file path.
      *
      * <p>This method is specifically for PrimeFaces-based CRUD templates.</p>
-     * @param log The logger used to log messages and errors.
-     * @param data The data model map containing values to populate the JSF CRUD template.
+     *
+     * @param log       The logger used to log messages and errors.
+     * @param data      The data model map containing values to populate the JSF CRUD template.
      * @param xhtmlPath The file path where the generated XHTML file will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
     public void createFacesCrudFile(Log log, Map<String, Object> data, Path xhtmlPath) throws IOException {
         createJavaFile(log, data, xhtmlPath, "xhtml/crud_prime.ftl");
     }
-    
+
     /**
      * Generates a Managed Bean CRUD file using a template and writes it to the specified file path.
      *
-     * @param log The logger used to log messages and errors.
+     * @param log       The logger used to log messages and errors.
      * @param fieldsMap The data model map containing values to populate the Managed Bean CRUD template.
-     * @param javaPath The file path where the generated Managed Bean CRUD file will be written.
+     * @param javaPath  The file path where the generated Managed Bean CRUD file will be written.
      * @throws IOException If an I/O error occurs during file writing.
      */
     public void createManagedBeanCrudFile(Log log, Map<String, Object> fieldsMap, Path javaPath) throws IOException {

--- a/src/main/resources/freemaker/java/AbstractModelRepository.ftl
+++ b/src/main/resources/freemaker/java/AbstractModelRepository.ftl
@@ -1,0 +1,23 @@
+package ${packageName};
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AbstractModelRepository
+<M,I> {
+
+List
+<M> findAll();
+
+    M save(M model);
+
+    Optional
+    <M> findById(I id);
+
+        void deleteById(I id);
+
+        void delete(M model);
+
+        void deleteAll(List
+        <M> models);
+            }

--- a/src/main/resources/freemaker/java/ModelRepository.ftl
+++ b/src/main/resources/freemaker/java/ModelRepository.ftl
@@ -6,20 +6,7 @@ import ${importItem};
     </#list>
 </#if>
 
-import java.util.List;
-import java.util.Optional;
+public interface ${modelName}Repository extends AbstractModelRepository<${modelName},${idClass}>{
 
-public interface ${modelName}Repository {
 
-  List<${modelName}> findAll();
-
-  ${modelName} save(${modelName} model) ;
-
-  Optional<${modelName}> findById(${idClass} id);
-
-  void deleteById(${idClass} id);
-
-  void delete(${modelName} model);
-
-  void deleteAll(List<${modelName}> models);
 }


### PR DESCRIPTION
…repository generation

- Added a new `AbstractModelRepository` interface in `freemaker` templates to standardize repository methods like `findAll`, `save`, `findById`, and `delete`.
- Updated `ModelRepository.ftl` templates to extend the `AbstractModelRepository` interface, reducing redundancy across generated repositories.
- Modified `ArchitectureHelper` to generate the `AbstractModelRepository` interface dynamically using the `createAbstractModelRepositoryInterface` method.
- Enhanced `TemplateUtil` to support the creation of `AbstractModelRepository.ftl` files and added the corresponding `createAbstractModelRepositoryFile` method.
- Adjusted JavaDocs for improved readability and aligned spacing within `TemplateUtil` class methods.
- Improved imports formatting consistency in the `ArchitectureHelper` class.