### PR TITLE
Refactor entity persistence logic and improve XML handling

### DIFF
--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PersistenceXmlHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PersistenceXmlHelper.java
@@ -39,7 +39,7 @@ import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
 public class PersistenceXmlHelper {
 
     public static final String NS_PERSISTENCE = "https://jakarta.ee/xml/ns/persistence";
-
+    public static final String JTA_DATA_SOURCE = "jta-data-source";
     private PersistenceXmlHelper() {
     }
 
@@ -143,12 +143,11 @@ public class PersistenceXmlHelper {
             .ifPresent(document -> {
                 var xmlUtil = XmlUtil.getInstance();
                 xmlUtil.findElementsStream(document,
-                        "//*[local-name()='persistence-unit'][@name='%s'][not(*[local-name()='jta-data-source' and text()='%s'])]"
-                            .formatted(persistenceUnit, name))
+                        "//*[local-name()='persistence-unit'][@name='%s']".formatted(persistenceUnit))
                     .findFirst()
-                    .ifPresent(element -> {
-                        xmlUtil.removeElement(element, "jta-data-source");
-                        xmlUtil.addElement(element, "jta-data-source").setText(name);
+                    .ifPresent(persistenceUnitElement -> {
+                        xmlUtil.removeElement(persistenceUnitElement, JTA_DATA_SOURCE);
+                        xmlUtil.addElementAsFirstChild(persistenceUnitElement, JTA_DATA_SOURCE, name);
                         var currentPath = mavenProject.getBasedir().toPath();
                         savePersistenceXml(currentPath, log, document);
                     });

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/XmlUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/XmlUtil.java
@@ -415,6 +415,22 @@ public class XmlUtil {
         Optional.ofNullable(element.element(qName)).ifPresent(element::remove);
     }
 
+    /**
+     * Adds a new element as the first child of the given parent element.
+     *
+     * @param parent      the parent element to which the new element will be added
+     * @param tagName     the tag name of the new element
+     * @param textContent the text content of the new element
+     * @return the newly created element
+     */
+    public Element addElementAsFirstChild(Element parent, String tagName, String textContent) {
+        QName qName = new QName(tagName, parent.getNamespace());
+        var element = DocumentHelper.createElement(qName);
+        element.setText(textContent);
+        parent.content().addFirst(element);
+        return element;
+    }
+
     private static class XmlUtilHolder {
 
         private static final XmlUtil INSTANCE = new XmlUtil();

--- a/src/main/resources/freemaker/java/Entity.ftl
+++ b/src/main/resources/freemaker/java/Entity.ftl
@@ -15,7 +15,7 @@ import ${importItem};
     </#list>
 </#if>
 
-@Entity<#if (entityName??)>( name ="${entityName}" ) </#if>
+@Entity
 <#if (tableName??)>
 @Table(name = "${tableName}")
 </#if>


### PR DESCRIPTION
### Summary
This pull request includes comprehensive refactoring to simplify and enhance entity persistence logic and XML handling utilities.

### Key Changes
- Removed the `addEntitiesToPersistenceXml` method and updated logic to handle `entitiesName` dynamically without modifying the persistence.xml directly.
- Introduced a new `addElementAsFirstChild` method in `XmlUtil` for flexible XML element insertion.
- Enhanced the `addElement` method in `XmlUtil` to return the created element, improving its usability.
- Streamlined `PersistenceXmlHelper` by introducing a constant for the `persistence` namespace and optimizing namespace handling.
- Added `xsi` namespace and `schemaLocation` attributes to the root persistence element in XML generation.
- Refactored XML generation logic for dynamic attribute handling during element creation.
- Simplified the FreeMarker template `Entity.ftl`, removing conditional annotations while retaining essential tableName logic.
- Improved code readability and maintainability by optimizing imports, eliminating redundancies, and fixing minor formatting issues.

### Additional Information
These changes aim to improve code clarity, reduce redundancy, and enhance the maintainability of entity persistence and XML-related functionalities.