### PR TITLE
feature/90 create datasource for payara

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ replay_pid*
 .idea
 target
 /nbactions.xml
+.agent
+*-REPORT.MD
+**/*.log

--- a/README.md
+++ b/README.md
@@ -1,309 +1,97 @@
 # Jakarta Coffee Builder Plugin
-![Maven Central Version](https://img.shields.io/maven-central/v/com.apuntesdejava/jakarta-coffee-builder-plugin)  ![GitHub last commit](https://img.shields.io/github/last-commit/jakarta-coffee-builder/jakarta-coffee-builder-plugin)  [![GitHub](https://img.shields.io/badge/maven-plugin-darkgreen?logo=github)](https://github.com/jakarta-coffee-builder/jakarta-coffee-builder-plugin)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/jakarta-coffee-builder/jakarta-coffee-builder-plugin/maven-ci-cd.yml)
 
-`develop`: ![GitHub branch check runs](https://img.shields.io/github/check-runs/jakarta-coffee-builder/jakarta-coffee-builder-plugin/develop) ![GitHub commit activity (branch)](https://img.shields.io/github/commit-activity/m/jakarta-coffee-builder/jakarta-coffee-builder-plugin/develop)
+Este plugin de Maven automatiza la configuración y el andamiaje (scaffolding) de proyectos Jakarta EE, facilitando la adopción de mejores prácticas y acelerando el desarrollo inicial.
 
+## 🚀 Uso desde la Línea de Comandos
 
-Maven plugin for adding and modifying Jakarta EE functionality to a project.
+Todos los "goals" del plugin pueden ejecutarse directamente sin necesidad de estar configurados en el `pom.xml`, utilizando la siguiente sintaxis:
 
-# Goals
-
-## Jakarta Faces
-
-### Add Jakarta Faces Configuration
-
-Add Jakarta Faces Servlet configuration in `web.xml` file
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-faces 
+```bash
+mvn com.apuntesdejava:jakarta-coffee-builder-plugin:<goal> -D<opcion>=<valor>
 ```
 
-**Result**
+---
 
-```java
-package com.application.app.faces;
+## 🏗️ Arquitectura y Scaffolding
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.faces.annotation.FacesConfig;
+### `add-domain-models`
+Genera capas de arquitectura (DTOs, Mappers, Repositorios y Servicios) basándose en una definición de entidades.
+- **`-Dentities-file=<path>`**: Ruta al archivo JSON con la definición de entidades. (**Requerido**)
 
-@FacesConfig
-@ApplicationScoped
-public class FacesConfiguration {
+### `create-openapi`
+Genera el código del lado del servidor (server-side) a partir de una especificación OpenAPI.
+- **`-Dopenapi-server=<path>`**: Ruta al archivo OpenAPI (yml/json). (Por defecto: `${project.basedir}/openapi.yml`)
 
-}
+---
+
+## 🎨 Jakarta Faces (JSF)
+
+### `add-faces`
+Configura Jakarta Faces en el proyecto (dependencias y declaración en `web.xml`).
+- **`-Dwelcome-file=<nombre>`**: Nombre del archivo de bienvenida. (Por defecto: `index.xhtml`)
+
+### `add-face-page`
+Agrega una nueva página JSF al proyecto.
+- **`-Dname=<nombre>`**: Nombre de la página (sin extensión). (**Requerido**)
+- **`-Dmanaged-bean=<true|false>`**: Indica si se debe crear un backing bean asociado. (Por defecto: `true`)
+- **`-Dtemplate=<nombre>`**: (Opcional) Nombre del template Facelet a utilizar.
+
+### `add-face-template`
+Crea un nuevo template Facelet.
+- **`-Dname=<nombre>`**: Nombre del template. (**Requerido**)
+- **`-Dinserts=<lista>`**: Lista separada por comas de nombres para los `ui:insert`.
+
+### `add-forms-from-entities`
+Genera formularios CRUD de JSF/PrimeFaces a partir de entidades.
+- **`-Dforms-file=<path>`**: Ruta al JSON de definición de formularios. (**Requerido**)
+- **`-Dentities-file=<path>`**: Ruta al JSON de definición de entidades. (**Requerido**)
+
+---
+
+## 🗄️ Persistencia y Datos
+
+### `add-persistence`
+Configura la unidad de persistencia (JPA).
+- **`-Dpersistence-unit-name=<nombre>`**: Nombre de la Persistence Unit. (Por defecto: `defaultPU`)
+- **`-Ddatasource-name=<nombre>`**: Nombre JNDI del Data Source. (Por defecto: `defaultDatasource`)
+- **`-Durl=<jdbc-url>`**: URL de conexión JDBC. (Por defecto: H2 in-memory)
+- **`-Duser=<usuario>`**: Usuario de base de datos.
+- **`-Dpassword=<clave>`**: Contraseña de base de datos.
+- **`-Ddeclare=<web|...>`**: Lugar donde declarar el recurso (Por defecto: `web`).
+
+### `add-datasource`
+Agrega la configuración de un Data Source.
+- *(Mismas opciones que `add-persistence`)*.
+
+### `add-entities`
+Integra definiciones de entidades JPA en el proyecto.
+- **`-Dentities-file=<path>`**: Ruta al archivo de definición de entidades. (**Requerido**)
+
+---
+
+## 🚀 Servidores de Aplicación y Microservicios
+
+### `add-glassfish-embedded`
+Configura un perfil de Maven para ejecutar con GlassFish Embedded.
+- **`-Dprofile=<nombre>`**: ID del perfil de Maven a crear. (Por defecto: `glassfish`)
+- **`-Dport=<puerto>`**: Puerto HTTP. (Por defecto: `8080`)
+- **`-DcontextRoot=<ruta>`**: Context root de la aplicación. (Por defecto: `${project.build.finalName}`)
+
+### `add-payaramicro`
+Configura el plugin y perfil para Payara Micro.
+- **`-Dprofile=<nombre>`**: ID del perfil de Maven a crear. (Por defecto: `payaramicro`)
+
+---
+
+## 🛠️ Utilidades
+
+### `add-validation-api`
+Agrega las dependencias de Jakarta Validation API para habilitar validaciones mediante anotaciones (`@NotNull`, `@Size`, etc.).
+
+---
+
+## 📝 Ejemplo Completo
+Para agregar una página de login utilizando un template existente y sin crear un backing bean:
+```bash
+mvn com.apuntesdejava:jakarta-coffee-builder-plugin:add-face-page -Dname=login -Dtemplate=mainTemplate -Dmanaged-bean=false
 ```
-
-**Showing**
-[![asciicast](https://asciinema.org/a/30Zyd628az3toF03XtZ5eSLRc.svg)](https://asciinema.org/a/30Zyd628az3toF03XtZ5eSLRc)
-
-### Add Jakarta Facelet Page (Template)
-
-Add a Facelet page
-
-```shell
-mvn "com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-template" 
-```
-
-**Parameters**
-
-| Parameter | Definition                     | Example                        |
-|-----------|--------------------------------|--------------------------------|
-| `name`    | Name of the Template to create | `/WEB-INF/templates/template1` |
-| `inserts` | Names of inserts block names   | `section1,section2,section3`   |
-
-
-
-**Example**
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-template \
-    -Dname=/WEB-INF/template/main.xhtml \
-    -Dinserts=header,body,footer
-```
-**Showing**
-[![asciicast](https://asciinema.org/a/tD2VpNkH5EHSQaTYRu9pasArc.svg)](https://asciinema.org/a/tD2VpNkH5EHSQaTYRu9pasArc)
-
-### Add Jakarta Faces Page
-
-Add a Face page, associating it with a Managed Bean. It can also be done by using a specified Facelet template
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-page
-```
-
-**Parameters**
-
-| Parameter      | Definition                                                                                            | Default value | Example                        |
-|----------------|-------------------------------------------------------------------------------------------------------|---------------|--------------------------------|
-| `name`         | Name of the Face page to create                                                                       |               |                                |
-| `managed-bean` | Boolean value indicating whether or not the Managed Bean class associated with the Face is created.   | `true`        |                                |
-| `template`     | Path of the Facelet template to be implemented for the Face to be created. This parameter is optional |               | `/WEB-INF/templates/template1` |
-
-
-
-**Example**
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-page \
-    -Dname=hello-world \
-    -Dmanaged-bean=false
-
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-page \
-    -Dname=persons \
-    -Dmanaged-bean=true
-
-```
-
-**Showing**
-
-Creating page with / without Managed Bean:
-[![asciicast](https://asciinema.org/a/And0N0LueNSaMCKV9VnyKm1gr.svg)](https://asciinema.org/a/And0N0LueNSaMCKV9VnyKm1gr)
-
-
-## Jakarta Persistence
-
-### Add Jakarta Persistence Configuration
-
-Add Jakarta Persistence configuration in `persistence.xml` file
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-persistence
-```
-
-**Parameters**
-
-| Parameter               | Definition                                                                                                             | Default value       |
-|-------------------------|------------------------------------------------------------------------------------------------------------------------|---------------------|
-| `datasource-name`       | This parameter defines the JNDI name of the DataSource. This value will be included in the DataSource configuration.   | `defaultDatasource` |
-| `url`                   | This parameter defines the URL of the DataSource. This value will be included in the DataSource configuration.         |                     |
-| `username`              | This parameter defines the username of the DataSource. This value will be included in the DataSource configuration.    |                     |
-| `password`              | This parameter defines the password of the DataSource. This value will be included in the DataSource configuration.    |                     |
-| `declare`               | Indicates how the DataSource is to be declared in the application. Possible values are `web.xml` `class`               | `class`             |
-| `server-name`           | This parameter defines the server name of the DataSource. This value will be included in the DataSource configuration. |                     |
-| `port-number`           | This parameter defines the port number of the DataSource. This value will be included in the DataSource configuration. |                     |
-| `properties`            | This parameter defines the properties of the DataSource. This value will be included in the DataSource configuration.  |                     |
-| `persistence-unit-name` | This parameter defines the name of the persistence unit. This value will be included in the persistence configuration. |                     | 
-
-
-### Add DataSource configuration
-
-Add DataSource configuration
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-datasource
-```
-
-**Parameters**
-
-| Parameter               | Definition                                                                                                             | Default value       |
-|-------------------------|------------------------------------------------------------------------------------------------------------------------|---------------------|
-| `datasource-name`       | This parameter defines the JNDI name of the DataSource. This value will be included in the DataSource configuration.   | `defaultDatasource` |
-| `url`                   | This parameter defines the URL of the DataSource. This value will be included in the DataSource configuration.         |                     |
-| `username`              | This parameter defines the username of the DataSource. This value will be included in the DataSource configuration.    |                     |
-| `password`              | This parameter defines the password of the DataSource. This value will be included in the DataSource configuration.    |                     |
-| `declare`               | Indicates how the DataSource is to be declared in the application. Possible values are `web.xml` `class`               | `class`             |
-| `server-name`           | This parameter defines the server name of the DataSource. This value will be included in the DataSource configuration. |                     |
-| `port-number`           | This parameter defines the port number of the DataSource. This value will be included in the DataSource configuration. |                     |
-| `properties`            | This parameter defines the properties of the DataSource. This value will be included in the DataSource configuration.  |                     |
-| `persistence-unit-name` | This parameter defines the name of the persistence unit. This value will be included in the persistence configuration. |                     | 
-
-
-### Add Jakarta Persistence Entity
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-entities
-
-```
-
-**Parameters**
-
-| Parameter       | Definition                                                                                        | Example                                 |
-|-----------------|---------------------------------------------------------------------------------------------------|-----------------------------------------|
-| `entities-file` | The name of the json file that contains the list of entities and their definitions to be created. | [entities.json](examples/entities.json) |
-
-**Example JSON File**
-```json
-{
-  "Category": {
-    "fields": {
-      "id": {
-        "type": "UUID",
-        "isId": true,
-        "generatedValue": "UUID"
-      },
-      "name": {
-        "type": "String",
-        "column": {
-          "length": 100
-        }
-      }
-    }
-  },
-  "Pet": {
-    "fields": {
-      "id": {
-        "type": "Long",
-        "isId": true,
-        "generatedValue": "Identity"
-      },
-      "category": {
-        "type": "Category",
-        "manyToOne": true,
-        "joinColumn": {
-          "name": "category_id",
-          "nullable": false
-        }
-      },
-      "name": {
-        "type": "String",
-        "column": {
-          "length": 100
-        }
-      },
-      "status": {
-        "type": "String"
-      }
-    }
-  } 
-}
-```
-
-
-## Jakarta RESTful Web Services
-
-### Create REST services with OpenAPI specifications
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:create-openapi
-```
-
-**Parameters**
-
-| Parameter        | Definition                                                                        | Example                               |
-|------------------|-----------------------------------------------------------------------------------|---------------------------------------|
-| `openapi-server` | The name of the yml file is specified with the server-side OpenAPI specification. | [openapi.yaml](examples/openapi.yaml) |
-
-**Note**
-- Each endpoint must be identified by a label
-
-### Add Glassfish Embedded Plugin
-
-Add Glassfish Embedded Plugin
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-glassfish-embedded
-```
-
-
-**Parameters**
-
-| Parameter     | Definition                                                      | Default value                |
-|---------------|-----------------------------------------------------------------|------------------------------|
-| `profile`     | This parameter defines the ID of the Maven profile to be added. | `glassfish`                  |
-| `port`        | This parameter defines the GlassFish port                       | `8080`                       |
-| `contextRoot` | Application Web Context Root                                    | `${project.build.finalName}` |
-
-### Add PayaraMicro Plugin
-
-Add PayaraMicro Plugin
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-payaramicro
-```
-
-### Add Domain Model
-
-The domain model is based using the definition of entities
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-domain-models
-```
-
-**Parameters**
-
-| Parameter       | Definition                                                                                        | Example                                 |
-|-----------------|---------------------------------------------------------------------------------------------------|-----------------------------------------|
-| `entities-file` | The name of the json file that contains the list of entities and their definitions to be created. | [entities.json](examples/entities.json) |
-
-**Example**
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-domain-models \
-    -Dentities-file=entities.json
-```
-
-### Add Forms (Primefaces) from Entities
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-forms-from-entities
-```
-
-**Parameters**
-
-| Parameter       | Definition                                                                                         | Example                                 |
-|-----------------|----------------------------------------------------------------------------------------------------|-----------------------------------------|
-| `entities-file` | The name  of the json file that contains the list of entities and their definitions to be created. | [entities.json](examples/entities.json) |
-| `forms-file`    | The name of the json file that contains the list of forms and columns to Faces Pages               | [forms.json](examples/forms.json)       |
-
-
-**Example JSON File**
-```json
-{
-  "CategoryList": {
-    "entity": "Category",
-    "title": "Categories List",
-    "base": "/",
-    "template": {
-      "facelet": "/WEB-INF/templates/template1.xhtml",
-      "define": "body"
-    },
-    "fields": {
-      "id": {
-        "label": "Category Id"
-      },
-      "name": {
-        "label": "Category Name"
-      }
-    }
-  }
-}
-```
- 

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <maven.version>3.9.9</maven.version>
         <maven.compiler.release>21</maven.compiler.release>
         <maven-plugin-tools.version>3.15.2</maven-plugin-tools.version>
-        <mockito.version>5.20.0</mockito.version>
+        <mockito.version>5.21.0</mockito.version>
         <org.slf4j-version>2.0.17</org.slf4j-version>
-        <junit-jupiter.version>5.13.1</junit-jupiter.version>
+        <junit-jupiter.version>6.0.3</junit-jupiter.version>
     </properties>
     <scm>
         <connection>scm:git:git://github.com/jakarta-coffee-builder/jakarta-coffee-builder-plugin.git</connection>
@@ -106,11 +106,6 @@
             <version>1.1.7</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>5.5.1</version>
-        </dependency>
-        <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.10.1</version>
@@ -131,6 +126,17 @@
             <version>1.20.0</version>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
@@ -167,7 +173,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -253,8 +259,25 @@
                     </execution>
                 </executions>
             </plugin>
-
-
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -281,7 +304,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.1</version>
+                        <version>3.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.9.9</maven.version>
+        <maven.version>3.9.14</maven.version>
         <maven.compiler.release>21</maven.compiler.release>
         <maven-plugin-tools.version>3.15.2</maven-plugin-tools.version>
         <mockito.version>5.21.0</mockito.version>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.20.0</version>
+            <version>1.21.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -136,7 +136,8 @@
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
-        </dependency>        <dependency>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
@@ -165,7 +166,7 @@
     </dependencies>
 
     <build>
-        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+        <pluginManagement>
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
@@ -177,7 +178,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.1</version>
+                    <version>3.15.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
@@ -220,11 +221,6 @@
                     <goalPrefix>jakarta-coffee-builder</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-<!--                <executions>
-                    <execution>
-                        <goals><goal>descriptor</goal></goals>
-                    </execution>
-                </executions>-->
                 <executions>
                     <execution>
                         <id>mojo-descriptor</id>

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
@@ -254,24 +254,33 @@ public final class JakartaEeHelper {
      * @param log          The Maven logger for output.
      * @param declare      The strategy for declaring the data source (e.g., "web.xml", "payara").
      * @param json         A {@link JsonObject} containing the data source configuration parameters.
+     * @param profile   The profile name to which the data source configuration should be applied (if applicable).
      */
     public void addDataSource(MavenProject mavenProject,
                               Log log,
                               String declare,
-                              JsonObject json) {
+                              JsonObject json,
+                              String profile) {
         log.debug("Datasource:%s".formatted(json));
         DataSourceCreatorFactory
-            .getDataSourceCreator(mavenProject, log, declare)
+            .getDataSourceCreator(mavenProject, log, declare, profile)
             .ifPresent(dataSourceCreator -> {
                 try {
                     dataSourceCreator
                         .dataSourceParameters(json)
                         .build();
-                } catch (IOException e) {
+                } catch (IOException | MojoExecutionException e) {
                     log.error("Error creating datasource", e);
                     throw new RuntimeException(e);
                 }
             });
+    }
+
+    public void addDataSource(MavenProject mavenProject,
+                              Log log,
+                              String declare,
+                              JsonObject json ) {
+        addDataSource(mavenProject, log, declare, json, null);
     }
 
     /**

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
@@ -390,13 +390,15 @@ public final class JakartaEeHelper {
      */
     public void addJacksonDependency(MavenProject mavenProject, Log log) throws IOException {
         CoffeeBuilderUtil.getDependencyConfiguration("jackson-core")
-            .ifPresent(hibernate -> PomUtil
-                .setProperty(mavenProject, log, "jackson-core.version",
-                    hibernate.getString("version")));
-        PomUtil.addDependency(mavenProject, log, "com.fasterxml.jackson.core", "jackson-core",
-            "${jackson-core.version}");
-        PomUtil.addDependency(mavenProject, log, "com.fasterxml.jackson.core", "jackson-annotations",
-            "${jackson-core.version}");
+            .ifPresent(hibernate -> {
+                PomUtil .setProperty(mavenProject, log, "jackson-core.version",
+                                hibernate.getString("version"));
+                var groupId= hibernate.getString("groupId");
+            PomUtil.addDependency(mavenProject, log, groupId, "jackson-core",
+                "${jackson-core.version}");
+            PomUtil.addDependency(mavenProject, log, groupId, "jackson-annotations",
+                "${jackson-core.version}");
+        });
     }
 
     /**

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
@@ -81,11 +81,17 @@ public final class JakartaEeHelper {
     }
 
     private JakartaEeHelper() {
-        try {
-            CoffeeBuilderUtil.getSpecificationsDefinitions().ifPresent(specs -> this.specifications = specs);
-        } catch (IOException e) {
-            throw new RuntimeException(e.getMessage(), e);
+    }
+
+    private JsonObject getSpecifications() {
+        if (this.specifications == null) {
+            try {
+                CoffeeBuilderUtil.getSpecificationsDefinitions().ifPresent(specs -> this.specifications = specs);
+            } catch (IOException e) {
+                throw new RuntimeException("Error loading Jakarta EE specifications from remote resource", e);
+            }
         }
+        return this.specifications;
     }
 
     /**
@@ -99,7 +105,7 @@ public final class JakartaEeHelper {
     public void addJakartaCdiDependency(MavenProject mavenProject,
                                         Log log,
                                         String jakartaEeVersion) throws MojoExecutionException {
-        var jakartaCdiVersion = specifications.getJsonObject(jakartaEeVersion).getString(JAKARTA_ENTERPRISE_CDI_API);
+        var jakartaCdiVersion = getSpecifications().getJsonObject(jakartaEeVersion).getString(JAKARTA_ENTERPRISE_CDI_API);
         PomUtil.addDependency(mavenProject, log, JAKARTA_ENTERPRISE, JAKARTA_ENTERPRISE_CDI_API, jakartaCdiVersion,
             PROVIDED_SCOPE);
     }
@@ -114,7 +120,7 @@ public final class JakartaEeHelper {
     public void addJakartaFacesDependency(MavenProject mavenProject,
                                           Log log,
                                           String jakartaEeVersion) {
-        var jakartaFacesVersion = specifications.getJsonObject(jakartaEeVersion).getString(JAKARTA_FACES_API);
+        var jakartaFacesVersion = getSpecifications().getJsonObject(jakartaEeVersion).getString(JAKARTA_FACES_API);
         PomUtil.addDependency(mavenProject, log, JAKARTA_FACES, JAKARTA_FACES_API, jakartaFacesVersion, PROVIDED_SCOPE);
     }
 
@@ -147,7 +153,7 @@ public final class JakartaEeHelper {
     public void addJakartaTransactionDependency(MavenProject mavenProject,
                                                 Log log,
                                                 String jakartaEeVersion) {
-        Optional.ofNullable(specifications.getJsonObject(jakartaEeVersion)
+        Optional.ofNullable(getSpecifications().getJsonObject(jakartaEeVersion)
                 .getString(JAKARTA_TRANSACTION_API))
             .ifPresentOrElse(jakartaPersistenceVersion -> PomUtil.addDependency(mavenProject,
                     log,
@@ -218,7 +224,7 @@ public final class JakartaEeHelper {
     public void addJakartaPersistenceDependency(MavenProject mavenProject,
                                                 Log log,
                                                 String jakartaEeVersion) {
-        var jakartaPersistenceVersion = specifications.getJsonObject(jakartaEeVersion)
+        var jakartaPersistenceVersion = getSpecifications().getJsonObject(jakartaEeVersion)
             .getString(JAKARTA_PERSISTENCE_API);
         PomUtil.addDependency(mavenProject, log, JAKARTA_PERSISTENCE, JAKARTA_PERSISTENCE_API,
             jakartaPersistenceVersion, PROVIDED_SCOPE);
@@ -279,7 +285,7 @@ public final class JakartaEeHelper {
     public void addJakartaDataDependency(MavenProject mavenProject,
                                          Log log,
                                          String jakartaEeVersion) throws MojoExecutionException {
-        var jakartaPersistenceVersion = specifications.getJsonObject(jakartaEeVersion).getString(JAKARTA_DATA_API);
+        var jakartaPersistenceVersion = getSpecifications().getJsonObject(jakartaEeVersion).getString(JAKARTA_DATA_API);
         PomUtil.addDependency(mavenProject,
             log,
             JAKARTA_DATA,
@@ -301,7 +307,7 @@ public final class JakartaEeHelper {
             artifact -> {
                 var version = artifact.getVersion();
                 log.debug("Jakarta CDI dependency found: " + version);
-                specifications.entrySet().stream()
+                getSpecifications().entrySet().stream()
                     .filter(entry -> {
                         JsonObject specObject = entry.getValue().asJsonObject();
                         return specObject.containsKey(JAKARTA_ENTERPRISE_CDI_API)

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
@@ -78,7 +78,7 @@ public class PayaraMicroHelper {
         if (!definition.containsKey(jakartaEeVersion))
             throw new MojoExecutionException("Jakarta EE version " + jakartaEeVersion + " doesn't exist");
         var configuration = Json.createObjectBuilder()
-            .add("payaraVersion", definition.getString(jakartaEeVersion))
+            .add("payaraMicroVersion", definition.getString(jakartaEeVersion))
             .add("deployWar", "false")
             .add("commandLineOptions",
                 Json.createObjectBuilder()
@@ -98,13 +98,21 @@ public class PayaraMicroHelper {
             )
             .build();
         var build = MavenProjectUtil.getBuild(mavenProject, profileId);
-        var plugin = PomUtil.addPlugin(build, log, "fish.payara.maven.plugins",
-            "payara-micro-maven-plugin", "2.4",
-            configuration);
-        log.debug("plugin: %s".formatted(plugin));
 
+        CoffeeBuilderUtil.getDependencyConfiguration("payara-micro-maven-plugin")
+                .ifPresent(pluginDef->{
+                    PomUtil.setProperty(mavenProject, log, "payara-micro-maven-plugin.version", pluginDef.getString("version"));
+                    PomUtil.addPlugin(build, log,
+                            pluginDef.getString("groupId"),
+                            pluginDef.getString("artifactId"),
+                            "${payara-micro-maven-plugin.version}",
+                            configuration
+                    );
+                });
 
     }
+
+
 
     private static class PayaraMicroHelperHolder {
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
@@ -1,0 +1,20 @@
+package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
+
+import java.io.IOException;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+
+public class DataSourceAsAdminCreator extends DataSourceCreator {
+
+  public DataSourceAsAdminCreator(MavenProject mavenProject, Log log) {
+    super(mavenProject, log);
+  }
+
+  @Override
+  public void build() throws IOException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'build'");
+  }
+
+}

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
@@ -1,20 +1,48 @@
 package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
 
-import java.io.IOException;
-
+import org.apache.commons.lang3.Strings;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Set;
+
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.CLASS_NAME;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
+
 public class DataSourceAsAdminCreator extends DataSourceCreator {
 
-  public DataSourceAsAdminCreator(MavenProject mavenProject, Log log) {
-    super(mavenProject, log);
-  }
+    public DataSourceAsAdminCreator(MavenProject mavenProject, Log log) {
+        super(mavenProject, log);
+    }
 
-  @Override
-  public void build() throws IOException {
-    // TODO Auto-generated method stub
-    throw new UnsupportedOperationException("Unimplemented method 'build'");
-  }
+    @Override
+    public void build() throws IOException {
+        var currentPath = mavenProject.getFile().toPath().getParent();
+        var postBootPath = currentPath.resolve("post-boot-commands.asadmin");
+        log.debug("Creating %s file".formatted(postBootPath));
+        var properties = getDataSourceParameters();
+        var commands = new StringBuilder();
+        commands.append("create-jdbc-connection-pool  ");
+        commands.append("--restype javax.sql.DataSource ");
+        commands.append("--datasourceclassname %s ".formatted(properties.get(CLASS_NAME)));
+        commands.append("--property \"");
+        properties.entrySet()
+            .stream()
+            .filter(entry -> !Set.of(CLASS_NAME, NAME).contains(entry.getKey()))
+            .forEach((entry) -> commands.append(entry.getKey())
+                .append("=")
+                .append(replaceColons((String) entry.getValue()))
+                .append(":"));
+        commands.deleteCharAt(commands.length() - 1);
+        commands.append("\" ");
 
+        Files.writeString(postBootPath, commands.toString());
+
+    }
+
+    private static String replaceColons(String value) {
+        return Strings.CS.replace(value, ":", "\\\\:");
+    }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
@@ -1,11 +1,19 @@
 package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.maven.model.ConfigurationContainer;
+import org.apache.maven.model.Profile;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.CLASS_NAME;
@@ -13,36 +21,94 @@ import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
 
 public class DataSourceAsAdminCreator extends DataSourceCreator {
 
-    public DataSourceAsAdminCreator(MavenProject mavenProject, Log log) {
-        super(mavenProject, log);
+    public DataSourceAsAdminCreator(MavenProject mavenProject, Log log, String profile) {
+        super(mavenProject, log, profile);
     }
 
     @Override
-    public void build() throws IOException {
+    public void build() throws IOException, MojoExecutionException {
         var currentPath = mavenProject.getFile().toPath().getParent();
         var postBootPath = currentPath.resolve("post-boot-commands.asadmin");
+        createPostBootPath(postBootPath);
+        insertOption();
+    }
+
+    private void insertOption() throws MojoExecutionException {
+        var model = mavenProject.getOriginalModel();
+        var build = Objects.isNull(profile)
+                ? model.getBuild()
+                : model.getProfiles().stream()
+                  .filter(p -> p.getId().equals(profile))
+                  .findFirst()
+                  .map(Profile::getBuild)
+                  .orElseThrow();
+        var config = build.getPlugins()
+                .stream()
+                .filter(p ->
+                        Strings.CI.equals(p.getGroupId(), "fish.payara.maven.plugins")
+                                && Strings.CI.equals(p.getArtifactId(), "payara-micro-maven-plugin")
+                ).map(ConfigurationContainer::getConfiguration)
+                .map(Xpp3Dom.class::cast)
+                .findFirst()
+                .orElseThrow();
+        var commandLineOptions = config.getChild("commandLineOptions");
+        var options = commandLineOptions.getChildren("option");
+        if (options == null)
+            throw new MojoExecutionException("commandLineOptions must have at least one option child");
+        var notFound = Arrays.stream(options)
+                .filter(option -> {
+                    var key = option.getChild("key");
+                    if (key == null)
+                        return false;
+                    return key.getValue().equals("--postbootcommandfile");
+                }).findFirst()
+                .isEmpty();
+        if (notFound) {
+            var newOption = new Xpp3Dom("option");
+            var keyTag = new Xpp3Dom("key");
+            keyTag.setValue("--postbootcommandfile");
+
+            var valueTag = new Xpp3Dom("value");
+            valueTag.setValue("post-boot-commands.asadmin");
+
+            newOption.addChild(keyTag);
+            newOption.addChild(valueTag);
+            commandLineOptions.addChild(newOption);
+        }
+    }
+
+    private void createPostBootPath(Path postBootPath) throws IOException {
         log.debug("Creating %s file".formatted(postBootPath));
         var properties = getDataSourceParameters();
         var commands = new StringBuilder();
-        commands.append("create-jdbc-connection-pool  ");
+        commands.append("create-jdbc-connection-pool ");
         commands.append("--restype javax.sql.DataSource ");
         commands.append("--datasourceclassname %s ".formatted(properties.get(CLASS_NAME)));
         commands.append("--property \"");
         properties.entrySet()
-            .stream()
-            .filter(entry -> !Set.of(CLASS_NAME, NAME).contains(entry.getKey()))
-            .forEach((entry) -> commands.append(entry.getKey())
-                .append("=")
-                .append(replaceColons((String) entry.getValue()))
-                .append(":"));
+                .stream()
+                .filter(entry -> !Set.of(CLASS_NAME, NAME).contains(entry.getKey()))
+                .forEach((entry) -> commands.append(entry.getKey())
+                        .append("=")
+                        .append(replaceSpecialCharacters((String) entry.getValue()))
+                        .append(":"));
         commands.deleteCharAt(commands.length() - 1);
         commands.append("\" ");
+        var name = String.valueOf(getDataSourceParameters().get(NAME));
+        var dataSourceName = StringUtils.substringAfterLast(name, "/") + "Pool";
+        commands.append(dataSourceName);
+        commands.append(System.lineSeparator());
+
+        commands.append("create-jdbc-resource ");
+        commands.append("--connectionpoolid %s ".formatted(dataSourceName));
+        commands.append(name);
 
         Files.writeString(postBootPath, commands.toString());
-
     }
 
-    private static String replaceColons(String value) {
-        return Strings.CS.replace(value, ":", "\\\\:");
+    private static String replaceSpecialCharacters(String value) {
+        String[] searchList = {":", "=", ";"};
+        String[] replaceList = {"\\:", "\\=", "\\;"};
+        return StringUtils.replaceEach(value, searchList, replaceList);
     }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreator.java
@@ -18,6 +18,7 @@ package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
@@ -50,15 +51,25 @@ public abstract class DataSourceCreator {
      */
     protected JsonObject dataSourceParameters;
 
+    protected String profile;
+
+    public DataSourceCreator(MavenProject mavenProject, Log log){
+        this.log = log;
+        this.mavenProject = mavenProject;
+        this.profile = null;
+    }
+
     /**
      * Constructor for DataSourceCreator.
      *
      * @param mavenProject the Maven project
      * @param log          the logger
+     * @param profile      the profile name
      */
-    public DataSourceCreator(MavenProject mavenProject, Log log) {
+    public DataSourceCreator(MavenProject mavenProject, Log log, String profile) {
         this.log = log;
         this.mavenProject = mavenProject;
+        this.profile = profile;
     }
 
     /**
@@ -111,5 +122,5 @@ public abstract class DataSourceCreator {
      *
      * @throws IOException if an I/O error occurs
      */
-    public abstract void build() throws IOException;
+    public abstract void build() throws IOException, MojoExecutionException;
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactory.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactory.java
@@ -29,20 +29,21 @@ public class DataSourceCreatorFactory {
     }
 
     /**
-     * Returns an Optional containing a DataSourceCreator based on the given declaration.
+     * Returns an Optional containing a DataSourceCreator based on the given
+     * declaration.
      *
      * @param mavenProject the Maven project
      * @param log          the logger
      * @param declare      the type of data source declaration
-     * @return an Optional containing a DataSourceCreator if the declaration matches, otherwise an empty Optional
+     * @return an Optional containing a DataSourceCreator if the declaration
+     *         matches, otherwise an empty Optional
      */
     public static Optional<DataSourceCreator> getDataSourceCreator(MavenProject mavenProject, Log log, String declare) {
-        if (declare.equals(Constants.DATASOURCE_DECLARE_WEB)) {
-            return Optional.of(new DataSourceWebCreator(mavenProject, log));
-        }
-        if (declare.equals(Constants.DATASOURCE_DECLARE_CLASS)) {
-            return Optional.of(new DataSourceClassCreator(mavenProject, log));
-        }
-        return Optional.empty();
+        return switch (declare) {
+            case Constants.DATASOURCE_DECLARE_WEB -> Optional.of(new DataSourceWebCreator(mavenProject, log));
+            case Constants.DATASOURCE_DECLARE_CLASS -> Optional.of(new DataSourceClassCreator(mavenProject, log));
+            case Constants.DATASOURCE_DECLARE_ASADMIN -> Optional.of(new DataSourceAsAdminCreator(mavenProject, log));
+            default -> Optional.empty();
+        };
     }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactory.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactory.java
@@ -35,15 +35,20 @@ public class DataSourceCreatorFactory {
      * @param mavenProject the Maven project
      * @param log          the logger
      * @param declare      the type of data source declaration
+     * @param profile      the profile name
      * @return an Optional containing a DataSourceCreator if the declaration
-     *         matches, otherwise an empty Optional
+     * matches, otherwise an empty Optional
      */
-    public static Optional<DataSourceCreator> getDataSourceCreator(MavenProject mavenProject, Log log, String declare) {
+    public static Optional<DataSourceCreator> getDataSourceCreator(MavenProject mavenProject, Log log, String declare, String profile) {
         return switch (declare) {
             case Constants.DATASOURCE_DECLARE_WEB -> Optional.of(new DataSourceWebCreator(mavenProject, log));
             case Constants.DATASOURCE_DECLARE_CLASS -> Optional.of(new DataSourceClassCreator(mavenProject, log));
-            case Constants.DATASOURCE_DECLARE_ASADMIN -> Optional.of(new DataSourceAsAdminCreator(mavenProject, log));
+            case Constants.DATASOURCE_DECLARE_ASADMIN -> Optional.of(new DataSourceAsAdminCreator(mavenProject, log, profile));
             default -> Optional.empty();
         };
+    }
+
+    public static Optional<DataSourceCreator> getDataSourceCreator(MavenProject mavenProject, Log log, String declare ) {
+        return getDataSourceCreator(mavenProject,log,declare,null);
     }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/arch/AddDomainModelsMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/arch/AddDomainModelsMojo.java
@@ -104,7 +104,8 @@ public class AddDomainModelsMojo extends AbstractMojo {
         try {
             var log = getLog();
             init();
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
             var formsPath = validateFile(entitiesFile);
             var architectureHelper = ArchitectureHelper.getInstance();
             architectureHelper.checkDependency(mavenProject, log, jakartaEeVersion);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojo.java
@@ -95,7 +95,8 @@ public class AddFacesMojo extends AbstractMojo {
         try {
             MavenProject fullProject = MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject);
 
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
             log.info("Executing: welcome-file:%s".formatted(welcomeFile));
             log.debug("Project name:%s".formatted(mavenProject.getName()));
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojo.java
@@ -68,7 +68,8 @@ public class AddValidationApiMojo extends AbstractMojo {
         try {
             MavenProject fullProject = MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject);
 
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
 
             jakartaEeHelper.addJakartaValidationApiDependency(mavenProject, log, jakartaEeVersion);
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojo.java
@@ -88,7 +88,8 @@ public class AddPayaraMicroMojo extends AbstractMojo {
 
             MavenProject fullProject = MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject);
 
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
 
             PayaraMicroHelper.getInstance().addPlugin(mavenProject, getLog(), profileId, jakartaEeVersion);
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddAbstractPersistenceMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddAbstractPersistenceMojo.java
@@ -148,6 +148,12 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
      */
     protected MavenProject fullProject;
 
+
+    @Parameter(
+            property = "profile"
+    )
+    protected String profile;
+
     /**
      * Constructor default
      */
@@ -232,8 +238,8 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
             .ifPresent(definition -> {
                 jakartaEeHelper.checkDataDependencies(fullProject, log, definition);
                 jakartaEeHelper.addDataSource(fullProject, log, declare,
-                    getDataSourceProperties(json, definition.getString("dataSourceClass"))
-                );
+                    getDataSourceProperties(json, definition.getString("dataSourceClass")),
+                        profile);
             });
 
 //        CoffeeBuilderUtil.updateProjectConfiguration(mavenProject.getFile().toPath().getParent(), "jdbc", json);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojo.java
@@ -103,7 +103,8 @@ public class AddPersistenceMojo extends AddAbstractPersistenceMojo {
     private void checkDependency(Log log) throws MojoExecutionException {
         log.debug("checking Jakarta Persistence dependency");
         try {
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
 
             var jakartaEeHelper = JakartaEeHelper.getInstance();
             if (jakartaEeHelper.hasNotJakartaCdiDependency(fullProject, log)) {

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
@@ -124,7 +124,8 @@ public class CreateOpenApiMojo extends AbstractMojo {
         try {
             MavenProject fullProject = MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject);
 
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
 
             jakartaEeHelper.addJacksonDependency(mavenProject, log);
             jakartaEeHelper.addMicroprofileOpenApiApiDependency(mavenProject, log);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/Constants.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/Constants.java
@@ -18,8 +18,10 @@ package com.apuntesdejava.jakartacoffeebuilder.util;
 import java.util.Set;
 
 /**
- * Provides a central repository for constant values used throughout the Jakarta Coffee Builder plugin.
- * This class prevents the use of magic strings and provides a single source of truth for shared
+ * Provides a central repository for constant values used throughout the Jakarta
+ * Coffee Builder plugin.
+ * This class prevents the use of magic strings and provides a single source of
+ * truth for shared
  * identifiers, keys, and URLs.
  */
 public final class Constants {
@@ -234,6 +236,11 @@ public final class Constants {
      */
     public static final String DATASOURCE_DECLARE_CLASS = "class";
     /**
+     * Indicates that the datasource should be declared using the Payara asadmin
+     * command.
+     */
+    public static final String DATASOURCE_DECLARE_ASADMIN = "asadmin";
+    /**
      * Indicates a Payara-specific datasource declaration.
      */
     public static final String DATASOURCE_PAYARA = "payara";
@@ -299,7 +306,7 @@ public final class Constants {
      * A set of annotation names that are searched for within field definitions.
      */
     public static final Set<String> SEARCH_ANNOTATIONS_FIELD_KEYS = Set.of("Column", "JoinColumn", "ManyToOne",
-        "ElementCollection");
+            "ElementCollection");
     /**
      * A set of supported strategies for the {@code @GeneratedValue} annotation.
      */

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
@@ -14,6 +14,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DEV_BASE_URL;
@@ -58,9 +59,12 @@ public final class HttpUtil {
         var requestUrl = address + (parameters.length == 0 ? EMPTY : ("?" + queryParams));
         LOG.log(System.Logger.Level.DEBUG, () -> "Request URL:" + requestUrl);
 
-        try (var httpClient = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .build()) {
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor();
+             var httpClient = HttpClient.newBuilder()
+                     .executor(executor)
+                     .connectTimeout(Duration.ofSeconds(10))
+                     .build()) {
 
             var httpRequest = HttpRequest.newBuilder()
                     .uri(URI.create(requestUrl))

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
@@ -3,14 +3,16 @@ package com.apuntesdejava.jakartacoffeebuilder.util;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URI;
 import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.function.Function;
 
@@ -49,18 +51,28 @@ public final class HttpUtil {
     public static <T> T getContent(String address,
                                    Function<String, T> converter,
                                    Parameter... parameters) throws IOException {
-        try (final var httpClient = HttpClients.createDefault()) {
-            var queryParams = Arrays.stream(parameters)
-                    .map(p -> p.name() + "=" + URLEncoder.encode(p.value(), StandardCharsets.UTF_8))
-                    .reduce((p1, p2) -> p1 + "&" + p2)
-                    .orElse(EMPTY);
-            var requestUrl = address + (parameters.length == 0 ? EMPTY : ("?" + queryParams));
-            var httpGet = new HttpGet(requestUrl);
-            LOG.log(System.Logger.Level.DEBUG, () -> "Request URL:" + requestUrl);
-            return httpClient.execute(httpGet, response -> {
-                var responseString = EntityUtils.toString(response.getEntity());
-                return converter.apply(responseString);
-            });
+        var queryParams = Arrays.stream(parameters)
+                .map(p -> p.name() + "=" + URLEncoder.encode(p.value(), StandardCharsets.UTF_8))
+                .reduce((p1, p2) -> p1 + "&" + p2)
+                .orElse(EMPTY);
+        var requestUrl = address + (parameters.length == 0 ? EMPTY : ("?" + queryParams));
+        LOG.log(System.Logger.Level.DEBUG, () -> "Request URL:" + requestUrl);
+
+        try (var httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build()) {
+
+            var httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(requestUrl))
+                    .timeout(Duration.ofSeconds(10))
+                    .GET()
+                    .build();
+
+            var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            return converter.apply(response.body());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("HTTP request interrupted", e);
         }
     }
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/JsonUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/JsonUtil.java
@@ -1,6 +1,7 @@
 package com.apuntesdejava.jakartacoffeebuilder.util;
 
 import jakarta.json.Json;
+import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
@@ -50,13 +51,14 @@ public final class JsonUtil {
      * Returns {@code null} for {@code JsonValue.ValueType.NULL}.
      */
     public static Object getJsonValue(JsonValue jsonValue) {
-        return switch (jsonValue.getValueType()) {
-            case ARRAY -> jsonValue.asJsonArray();
-            case OBJECT -> jsonValue.asJsonObject();
-            case STRING -> ((JsonString) jsonValue).getString();
-            case NUMBER -> ((JsonNumber) jsonValue).numberValue();
-            case TRUE -> true;
-            case FALSE -> false;
+        return switch (jsonValue) {
+            case JsonString s -> s.getString();
+            case JsonNumber n -> n.numberValue();
+            case JsonObject o -> o;
+            case JsonArray a -> a;
+            case JsonValue v when v == JsonValue.TRUE -> true;
+            case JsonValue v when v == JsonValue.FALSE -> false;
+            case JsonValue v when v == JsonValue.NULL -> null;
             default -> null;
         };
     }
@@ -111,13 +113,19 @@ public final class JsonUtil {
         jsonObject.forEach((key, value) -> {
             if (allowRepeat || config.getChild(key) == null) {
 
-                switch (value.getValueType()) {
-                    case ARRAY -> evaluateArrayElement(config, log, key, value);
-                    case OBJECT -> evaluateObjectElement(config, log, key, value, allowRepeat);
-                    default -> {
+                switch (value) {
+                    case JsonArray a -> evaluateArrayElement(config, log, key, a);
+                    case JsonObject o -> evaluateObjectElement(config, log, key, o, allowRepeat);
+                    case JsonString s -> {
                         log.debug("---- in value");
                         Xpp3Dom child = new Xpp3Dom(key);
-                        child.setValue(((JsonString) value).getString());
+                        child.setValue(s.getString());
+                        config.addChild(child);
+                    }
+                    default -> {
+                        log.debug("---- in default value");
+                        Xpp3Dom child = new Xpp3Dom(key);
+                        child.setValue(value.toString());
                         config.addChild(child);
                     }
 

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactoryTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactoryTest.java
@@ -1,0 +1,56 @@
+package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_ASADMIN;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_CLASS;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_WEB;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class DataSourceCreatorFactoryTest {
+
+    private final MavenProject mockProject = mock(MavenProject.class);
+    private final Log mockLog = mock(Log.class);
+
+    @Test
+    @DisplayName("should return DataSourceWebCreator for web.xml declaration")
+    void returnsWebCreatorForWebXml() {
+        Optional<DataSourceCreator> creator = DataSourceCreatorFactory.getDataSourceCreator(
+            mockProject, mockLog, DATASOURCE_DECLARE_WEB);
+        assertTrue(creator.isPresent());
+        assertInstanceOf(DataSourceWebCreator.class, creator.get());
+    }
+
+    @Test
+    @DisplayName("should return DataSourceClassCreator for class declaration")
+    void returnsClassCreatorForClass() {
+        Optional<DataSourceCreator> creator = DataSourceCreatorFactory.getDataSourceCreator(
+            mockProject, mockLog, DATASOURCE_DECLARE_CLASS);
+        assertTrue(creator.isPresent());
+        assertInstanceOf(DataSourceClassCreator.class, creator.get());
+    }
+
+    @Test
+    @DisplayName("should return DataSourceAsAdminCreator for asadmin declaration")
+    void returnsAsAdminCreatorForAsadmin() {
+        Optional<DataSourceCreator> creator = DataSourceCreatorFactory.getDataSourceCreator(
+            mockProject, mockLog, DATASOURCE_DECLARE_ASADMIN);
+        assertTrue(creator.isPresent());
+        assertInstanceOf(DataSourceAsAdminCreator.class, creator.get());
+    }
+
+    @Test
+    @DisplayName("should return empty Optional for unknown declaration")
+    void returnsEmptyForUnknown() {
+        Optional<DataSourceCreator> creator = DataSourceCreatorFactory.getDataSourceCreator(
+            mockProject, mockLog, "unknown");
+        assertTrue(creator.isEmpty());
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/model/NamespaceContextMapTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/model/NamespaceContextMapTest.java
@@ -1,0 +1,58 @@
+package com.apuntesdejava.jakartacoffeebuilder.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NamespaceContextMapTest {
+
+    private static final String PREFIX = "ns";
+    private static final String URI = "http://example.com/ns";
+
+    private NamespaceContextMap context;
+
+    @BeforeEach
+    void setUp() {
+        context = new NamespaceContextMap(PREFIX, URI);
+    }
+
+    @Test
+    @DisplayName("getNamespaceURI: should return URI for known prefix")
+    void getNamespaceURI_knownPrefix_returnsUri() {
+        assertEquals(URI, context.getNamespaceURI(PREFIX));
+    }
+
+    @Test
+    @DisplayName("getNamespaceURI: should return empty string for unknown prefix")
+    void getNamespaceURI_unknownPrefix_returnsEmpty() {
+        assertEquals("", context.getNamespaceURI("unknown"));
+    }
+
+    @Test
+    @DisplayName("getPrefix: should return prefix for known URI")
+    void getPrefix_knownUri_returnsPrefix() {
+        assertEquals(PREFIX, context.getPrefix(URI));
+    }
+
+    @Test
+    @DisplayName("getPrefix: should return null for unknown URI")
+    void getPrefix_unknownUri_returnsNull() {
+        assertNull(context.getPrefix("http://unknown.com"));
+    }
+
+    @Test
+    @DisplayName("getPrefixes: should return iterator containing the known prefix")
+    void getPrefixes_returnsIteratorWithPrefix() {
+        Iterator<String> prefixes = context.getPrefixes(URI);
+        assertTrue(prefixes.hasNext());
+        assertEquals(PREFIX, prefixes.next());
+        assertFalse(prefixes.hasNext());
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/arch/AddDomainModelsMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/arch/AddDomainModelsMojoTest.java
@@ -1,0 +1,160 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.arch;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.ArchitectureHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.JsonUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddDomainModelsMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddDomainModelsMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JsonUtil> jsonUtilMockedStatic;
+    private MockedStatic<ArchitectureHelper> architectureHelperMockedStatic;
+
+    @Mock
+    private ArchitectureHelper architectureHelperMock;
+
+    private File tempFile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jsonUtilMockedStatic = mockStatic(JsonUtil.class);
+        architectureHelperMockedStatic = mockStatic(ArchitectureHelper.class);
+
+        architectureHelperMockedStatic.when(ArchitectureHelper::getInstance).thenReturn(architectureHelperMock);
+
+        tempFile = File.createTempFile("entities", ".json");
+        tempFile.deleteOnExit();
+
+        java.lang.reflect.Field entitiesFileField = AddDomainModelsMojo.class.getDeclaredField("entitiesFile");
+        entitiesFileField.setAccessible(true);
+        entitiesFileField.set(mojo, tempFile);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jsonUtilMockedStatic.close();
+        architectureHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add domain models successfully")
+    void execute_ValidProjectAndFile_AddsModels() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.of("10.0.0"));
+
+        JsonObject dummyJson = Json.createObjectBuilder().add("test", "data").build();
+        JsonValue dummyJsonValue = org.mockito.Mockito.mock(JsonValue.class);
+        lenient().when(dummyJsonValue.asJsonObject()).thenReturn(dummyJson);
+
+        jsonUtilMockedStatic.when(() -> JsonUtil.readJsonValue(any(Path.class)))
+            .thenReturn(dummyJsonValue);
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(architectureHelperMock).checkDependency(mavenProject, mockLog, "10.0.0");
+        verify(architectureHelperMock).createDtos(mavenProject, mockLog, dummyJson);
+        verify(architectureHelperMock).createMappers(mavenProject, mockLog, dummyJson);
+        verify(architectureHelperMock).createModelRepositoryInterfaces(mavenProject, mockLog, dummyJson);
+        verify(architectureHelperMock).createServices(mavenProject, mockLog, dummyJson);
+
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when entities file does not exist")
+    void execute_MissingFile_ThrowsException() throws Exception {
+        File nonExistent = new File("non-existent-file-12345.json");
+        java.lang.reflect.Field entitiesFileField = AddDomainModelsMojo.class.getDeclaredField("entitiesFile");
+        entitiesFileField.setAccessible(true);
+        entitiesFileField.set(mojo, nonExistent);
+
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.of("10.0.0"));
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("File not found"));
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when Jakarta EE version missing")
+    void execute_MissingJakartaEeVersion_ThrowsException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacePageMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacePageMojoTest.java
@@ -1,0 +1,93 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.faces;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaFacesHelper;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddFacePageMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddFacePageMojo mojo;
+
+    private MockedStatic<JakartaFacesHelper> jakartaFacesHelperMockedStatic;
+
+    @Mock
+    private JakartaFacesHelper jakartaFacesHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        jakartaFacesHelperMockedStatic = mockStatic(JakartaFacesHelper.class);
+        jakartaFacesHelperMockedStatic.when(JakartaFacesHelper::getInstance).thenReturn(jakartaFacesHelperMock);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddFacePageMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jakartaFacesHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add face page without template and with managed bean")
+    void execute_NoTemplateWithBean_AddsFacePage() throws Exception {
+        setField("pageName", "index.xhtml");
+        setField("createManagedBean", true);
+        setField("templateFacelet", null);
+
+        mojo.execute();
+
+        verify(jakartaFacesHelperMock).addFacePage(mavenProject, mockLog, "index.xhtml", true);
+        verify(jakartaFacesHelperMock).createManagedBean(mavenProject, mockLog, "index.xhtml");
+        verify(jakartaFacesHelperMock, never()).addFacePageWithFaceletTemplate(any(),
+            any(),
+            any(),
+            any(),
+            anyBoolean());
+    }
+
+    @Test
+    @DisplayName("execute: should add face page with template and without managed bean")
+    void execute_WithTemplateNoBean_AddsFacePageWithTemplate() throws Exception {
+        setField("pageName", "index.xhtml");
+        setField("createManagedBean", false);
+        setField("templateFacelet", "template.xhtml");
+
+        mojo.execute();
+
+        verify(jakartaFacesHelperMock).addFacePageWithFaceletTemplate(mavenProject,
+            mockLog,
+            "index.xhtml",
+            "template.xhtml",
+            false);
+        verify(jakartaFacesHelperMock, never()).addFacePage(any(), any(), any(), anyBoolean());
+        verify(jakartaFacesHelperMock, never()).createManagedBean(any(), any(), any());
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFaceTemplateMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFaceTemplateMojoTest.java
@@ -1,0 +1,69 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.faces;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaFacesHelper;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddFaceTemplateMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddFaceTemplateMojo mojo;
+
+    private MockedStatic<JakartaFacesHelper> jakartaFacesHelperMockedStatic;
+
+    @Mock
+    private JakartaFacesHelper jakartaFacesHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        jakartaFacesHelperMockedStatic = mockStatic(JakartaFacesHelper.class);
+        jakartaFacesHelperMockedStatic.when(JakartaFacesHelper::getInstance).thenReturn(jakartaFacesHelperMock);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddFaceTemplateMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jakartaFacesHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add face template successfully")
+    void execute_ValidTemplate_AddsTemplate() throws Exception {
+        setField("templateName", "myTemplate");
+        List<String> inserts = Arrays.asList("header", "footer");
+        setField("inserts", inserts);
+
+        mojo.execute();
+
+        verify(jakartaFacesHelperMock).addFaceTemplate(mavenProject, mockLog, "myTemplate", inserts);
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojoTest.java
@@ -1,0 +1,141 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.faces;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddFacesMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddFacesMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @BeforeEach
+    void setUp() {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add Faces configurations successfully")
+    void execute_ValidProject_AddsConfigurations() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.of("10.0.0"));
+
+        lenient().when(jakartaEeHelperMock.hasJakartaFacesDependency(fullProject, mockLog)).thenReturn(false);
+        lenient().when(jakartaEeHelperMock.hasNotJakartaCdiDependency(fullProject, mockLog)).thenReturn(true);
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).addJakartaFacesDependency(mavenProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addJakartaCdiDependency(mavenProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addJakartaFacesDeclaration(fullProject, mockLog);
+        verify(jakartaEeHelperMock).addWelcomePages(eq(fullProject), any(), eq(mockLog));
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should skip adding dependencies if already present")
+    void execute_DependenciesPresent_SkipsDependencies() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.of("10.0.0"));
+
+        lenient().when(jakartaEeHelperMock.hasJakartaFacesDependency(fullProject, mockLog)).thenReturn(true);
+        lenient().when(jakartaEeHelperMock.hasNotJakartaCdiDependency(fullProject, mockLog)).thenReturn(false);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock, never()).addJakartaFacesDependency(any(), any(), any());
+        verify(jakartaEeHelperMock, never()).addJakartaCdiDependency(any(), any(), any());
+        verify(jakartaEeHelperMock).addJakartaFacesDeclaration(fullProject, mockLog);
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when Jakarta EE version is missing")
+    void execute_MissingJakartaEeVersion_ThrowsMojoExecutionException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFormsFromEntitiesMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFormsFromEntitiesMojoTest.java
@@ -1,0 +1,131 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.faces;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.PrimeFacesHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddFormsFromEntitiesMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddFormsFromEntitiesMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<PrimeFacesHelper> primeFacesHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private PrimeFacesHelper primeFacesHelperMock;
+
+    private File tempFormsFile;
+    private File tempEntitiesFile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        primeFacesHelperMockedStatic = mockStatic(PrimeFacesHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        primeFacesHelperMockedStatic.when(PrimeFacesHelper::getInstance).thenReturn(primeFacesHelperMock);
+
+        tempFormsFile = File.createTempFile("forms", ".json");
+        tempFormsFile.deleteOnExit();
+
+        tempEntitiesFile = File.createTempFile("entities", ".json");
+        tempEntitiesFile.deleteOnExit();
+
+        setField("formsFile", tempFormsFile);
+        setField("entitiesFile", tempEntitiesFile);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddFormsFromEntitiesMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+        primeFacesHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add forms from entities successfully")
+    void execute_ValidFiles_AddsForms() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        when(jakartaEeHelperMock.hasNotPrimeFacesDependency(fullProject, mockLog)).thenReturn(true);
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).addPrimeFacesDependency(mavenProject, mockLog);
+        verify(primeFacesHelperMock).addFormsFromEntities(fullProject,
+            mockLog,
+            tempFormsFile.toPath(),
+            tempEntitiesFile.toPath());
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when forms file does not exist")
+    void execute_MissingFormsFile_ThrowsMojoExecutionException() throws Exception {
+        File nonExistent = new File("non-existent-form-file.json");
+        setField("formsFile", nonExistent);
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("File not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/glassfish/AddGlassFishEmbeddedMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/glassfish/AddGlassFishEmbeddedMojoTest.java
@@ -1,0 +1,79 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.glassfish;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.GlassFishHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddGlassFishEmbeddedMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddGlassFishEmbeddedMojo mojo;
+
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<GlassFishHelper> glassFishHelperMockedStatic;
+
+    @Mock
+    private GlassFishHelper glassFishHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        glassFishHelperMockedStatic = mockStatic(GlassFishHelper.class);
+
+        glassFishHelperMockedStatic.when(GlassFishHelper::getInstance).thenReturn(glassFishHelperMock);
+
+        // Inject private fields that would normally be injected by Maven
+        java.lang.reflect.Field profileIdField = AddGlassFishEmbeddedMojo.class.getDeclaredField("profileId");
+        profileIdField.setAccessible(true);
+        profileIdField.set(mojo, "glassfish");
+
+        java.lang.reflect.Field portField = AddGlassFishEmbeddedMojo.class.getDeclaredField("port");
+        portField.setAccessible(true);
+        portField.set(mojo, 8080);
+
+        java.lang.reflect.Field contextRootField = AddGlassFishEmbeddedMojo.class.getDeclaredField("contextRoot");
+        contextRootField.setAccessible(true);
+        contextRootField.set(mojo, "my-app");
+    }
+
+    @AfterEach
+    void tearDown() {
+        pomUtilMockedStatic.close();
+        glassFishHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add GlassFish embedded plugin successfully")
+    void execute_ValidProject_AddsPlugin() throws Exception {
+        doNothing().when(glassFishHelperMock).addPlugin(mavenProject, mockLog, "glassfish", 8080, "my-app");
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(glassFishHelperMock).addPlugin(mavenProject, mockLog, "glassfish", 8080, "my-app");
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojoTest.java
@@ -1,0 +1,119 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.jakartaee;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class AddValidationApiMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddValidationApiMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @BeforeEach
+    void setUp() {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add validation API when full project is resolved and version exists")
+    void execute_ValidProject_AddsDependency() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.of("10.0.0"));
+
+        doNothing().when(jakartaEeHelperMock).addJakartaValidationApiDependency(mavenProject, mockLog, "10.0.0");
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).addJakartaValidationApiDependency(mavenProject, mockLog, "10.0.0");
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when Jakarta EE version is missing")
+    void execute_MissingJakartaEeVersion_ThrowsMojoExecutionException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+        
+        verifyNoInteractions(jakartaEeHelperMock);
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoFailureException when project builder fails")
+    void execute_ProjectBuilderFails_ThrowsMojoFailureException() throws Exception {
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenThrow(new ProjectBuildingException("test", "Error building", new Exception()));
+
+        assertThrows(MojoFailureException.class, () -> mojo.execute());
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojoTest.java
@@ -1,0 +1,124 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.payara;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.PayaraMicroHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddPayaraMicroMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddPayaraMicroMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<PayaraMicroHelper> payaraMicroHelperMockedStatic;
+
+    @Mock
+    private PayaraMicroHelper payaraMicroHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        payaraMicroHelperMockedStatic = mockStatic(PayaraMicroHelper.class);
+
+        payaraMicroHelperMockedStatic.when(PayaraMicroHelper::getInstance).thenReturn(payaraMicroHelperMock);
+
+        java.lang.reflect.Field profileIdField = AddPayaraMicroMojo.class.getDeclaredField("profileId");
+        profileIdField.setAccessible(true);
+        profileIdField.set(mojo, "payaramicro");
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        payaraMicroHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add Payara Micro plugin successfully")
+    void execute_ValidProject_AddsPlugin() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.of("10.0.0"));
+
+        doNothing().when(payaraMicroHelperMock).addPlugin(mavenProject, mockLog, "payaramicro", "10.0.0");
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(payaraMicroHelperMock).addPlugin(mavenProject, mockLog, "payaramicro", "10.0.0");
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when Jakarta EE version is missing")
+    void execute_MissingJakartaEeVersion_ThrowsMojoExecutionException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+
+    @Test
+    @DisplayName("execute: should catch and log exception on project building failure")
+    void execute_ProjectBuilderFails_LogsError() throws Exception {
+        ProjectBuildingException buildException = new ProjectBuildingException("test", "Error building", new Exception());
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenThrow(buildException);
+
+        mojo.execute();
+
+        verify(mockLog).error(eq("Error building for project test"), eq(buildException));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
@@ -1,0 +1,119 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.persistence;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.PersistenceXmlHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.CoffeeBuilderUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import jakarta.json.Json;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddDataSourceMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddDataSourceMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<PersistenceXmlHelper> persistenceXmlHelperMockedStatic;
+    private MockedStatic<CoffeeBuilderUtil> coffeeBuilderUtilMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private PersistenceXmlHelper persistenceXmlHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        persistenceXmlHelperMockedStatic = mockStatic(PersistenceXmlHelper.class);
+        coffeeBuilderUtilMockedStatic = mockStatic(CoffeeBuilderUtil.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        persistenceXmlHelperMockedStatic.when(PersistenceXmlHelper::getInstance).thenReturn(persistenceXmlHelperMock);
+
+        setField("datasourceName", "myDS");
+        setField("url", "jdbc:h2:mem:test");
+        setField("declare", "web");
+        setField("persistenceUnitName", "myPU");
+        setField("mavenProject", mavenProject);
+        setField("mavenSession", mavenSession);
+        setField("projectBuilder", projectBuilder);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddAbstractPersistenceMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+        persistenceXmlHelperMockedStatic.close();
+        coffeeBuilderUtilMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add data source successfully")
+    void execute_ValidProject_AddsDataSource() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        var jdbcConfig = Json.createObjectBuilder().add("dataSourceClass", "org.h2.jdbcx.JdbcDataSource").build();
+        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration("jdbc:h2:mem:test"))
+                .thenReturn(Optional.of(jdbcConfig));
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(fullProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(persistenceXmlHelperMock).addDataSourceToPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"), eq("jdbc/myDS"));
+        verify(jakartaEeHelperMock).checkDataDependencies(eq(fullProject), eq(mockLog), eq(jdbcConfig));
+        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any());
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(fullProject, mockLog));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
@@ -113,7 +113,7 @@ class AddDataSourceMojoTest {
 
         verify(persistenceXmlHelperMock).addDataSourceToPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"), eq("jdbc/myDS"));
         verify(jakartaEeHelperMock).checkDataDependencies(eq(fullProject), eq(mockLog), eq(jdbcConfig));
-        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any());
+        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any(), any());
         pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(fullProject, mockLog));
     }
 }

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddEntitiesMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddEntitiesMojoTest.java
@@ -1,0 +1,110 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.persistence;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaPersistenceHelper;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddEntitiesMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddEntitiesMojo mojo;
+
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<JakartaPersistenceHelper> jakartaPersistenceHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private JakartaPersistenceHelper jakartaPersistenceHelperMock;
+
+    private File tempFile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        jakartaPersistenceHelperMockedStatic = mockStatic(JakartaPersistenceHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        jakartaPersistenceHelperMockedStatic.when(JakartaPersistenceHelper::getInstance).thenReturn(jakartaPersistenceHelperMock);
+
+        tempFile = File.createTempFile("entities", ".json");
+        tempFile.deleteOnExit();
+
+        java.lang.reflect.Field entitiesFileField = AddEntitiesMojo.class.getDeclaredField("entitiesFile");
+        entitiesFileField.setAccessible(true);
+        entitiesFileField.set(mojo, tempFile);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jakartaEeHelperMockedStatic.close();
+        jakartaPersistenceHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add entities successfully")
+    void execute_ValidFileAndProject_AddsEntities() throws Exception {
+        Path mockPersistenceXmlPath = Paths.get("src/main/resources/META-INF/persistence.xml");
+        when(jakartaEeHelperMock.getPersistenceXmlPath(mavenProject))
+                .thenReturn(Optional.of(mockPersistenceXmlPath));
+
+        mojo.execute();
+
+        verify(jakartaPersistenceHelperMock).addEntities(mavenProject, mockLog, tempFile.toPath(), mockPersistenceXmlPath);
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when entities file does not exist")
+    void execute_MissingEntitiesFile_ThrowsMojoExecutionException() throws Exception {
+        File nonExistent = new File("non-existent-file-12345.json");
+        java.lang.reflect.Field entitiesFileField = AddEntitiesMojo.class.getDeclaredField("entitiesFile");
+        entitiesFileField.setAccessible(true);
+        entitiesFileField.set(mojo, nonExistent);
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Error adding entities"));
+        verify(mockLog).error("Entities file not found: " + nonExistent.getAbsolutePath());
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when persistence.xml not found")
+    void execute_MissingPersistenceXml_ThrowsMojoExecutionException() throws Exception {
+        when(jakartaEeHelperMock.getPersistenceXmlPath(mavenProject))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Error adding entities"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
@@ -1,0 +1,152 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.persistence;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.PersistenceXmlHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.CoffeeBuilderUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import jakarta.json.Json;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddPersistenceMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddPersistenceMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<PersistenceXmlHelper> persistenceXmlHelperMockedStatic;
+    private MockedStatic<CoffeeBuilderUtil> coffeeBuilderUtilMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private PersistenceXmlHelper persistenceXmlHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        persistenceXmlHelperMockedStatic = mockStatic(PersistenceXmlHelper.class);
+        coffeeBuilderUtilMockedStatic = mockStatic(CoffeeBuilderUtil.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        persistenceXmlHelperMockedStatic.when(PersistenceXmlHelper::getInstance).thenReturn(persistenceXmlHelperMock);
+
+        setField("datasourceName", "myDS");
+        setField("url", "jdbc:h2:mem:test");
+        setField("declare", "web");
+        setField("persistenceUnitName", "myPU");
+        setField("mavenProject", mavenProject);
+        setField("mavenSession", mavenSession);
+        setField("projectBuilder", projectBuilder);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddAbstractPersistenceMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+        persistenceXmlHelperMockedStatic.close();
+        coffeeBuilderUtilMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add persistence configuration successfully")
+    void execute_ValidProject_AddsPersistence() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        var jdbcConfig = Json.createObjectBuilder().add("dataSourceClass", "org.h2.jdbcx.JdbcDataSource").build();
+        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration("jdbc:h2:mem:test"))
+                .thenReturn(Optional.of(jdbcConfig));
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.of("10.0.0"));
+
+        lenient().when(jakartaEeHelperMock.hasNotJakartaCdiDependency(fullProject, mockLog)).thenReturn(true);
+        lenient().when(jakartaEeHelperMock.hasNotJakartaPersistenceDependency(fullProject, mockLog)).thenReturn(true);
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(fullProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).createPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"));
+        verify(persistenceXmlHelperMock).addDataSourceToPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"), eq("jdbc/myDS"));
+        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any());
+        
+        verify(jakartaEeHelperMock).addJakartaCdiDependency(mavenProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addJakartaPersistenceDependency(fullProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addPersistenceClassProvider(mavenProject, mockLog);
+
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(fullProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when Jakarta EE version missing")
+    void execute_MissingJakartaEeVersion_ThrowsException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        var jdbcConfig = Json.createObjectBuilder().add("dataSourceClass", "org.h2.jdbcx.JdbcDataSource").build();
+        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration("jdbc:h2:mem:test"))
+                .thenReturn(Optional.of(jdbcConfig));
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
@@ -82,6 +82,7 @@ class AddPersistenceMojoTest {
         setField("mavenProject", mavenProject);
         setField("mavenSession", mavenSession);
         setField("projectBuilder", projectBuilder);
+        setField("profile", "default");
     }
 
     private void setField(String fieldName, Object value) throws Exception {
@@ -123,8 +124,8 @@ class AddPersistenceMojoTest {
 
         verify(jakartaEeHelperMock).createPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"));
         verify(persistenceXmlHelperMock).addDataSourceToPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"), eq("jdbc/myDS"));
-        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any());
-        
+        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any(), any());
+
         verify(jakartaEeHelperMock).addJakartaCdiDependency(mavenProject, mockLog, "10.0.0");
         verify(jakartaEeHelperMock).addJakartaPersistenceDependency(fullProject, mockLog, "10.0.0");
         verify(jakartaEeHelperMock).addPersistenceClassProvider(mavenProject, mockLog);

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojoTest.java
@@ -1,0 +1,128 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.rest;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.OpenApiGeneratorHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CreateOpenApiMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private CreateOpenApiMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<OpenApiGeneratorHelper> openApiGeneratorHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private OpenApiGeneratorHelper openApiGeneratorHelperMock;
+
+    private File tempFile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        openApiGeneratorHelperMockedStatic = mockStatic(OpenApiGeneratorHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        openApiGeneratorHelperMockedStatic.when(OpenApiGeneratorHelper::getInstance).thenReturn(openApiGeneratorHelperMock);
+
+        tempFile = File.createTempFile("openapi", ".yml");
+        tempFile.deleteOnExit();
+
+        java.lang.reflect.Field openApiFileServerField = CreateOpenApiMojo.class.getDeclaredField("openApiFileServer");
+        openApiFileServerField.setAccessible(true);
+        openApiFileServerField.set(mojo, tempFile);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+        openApiGeneratorHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add OpenAPI configurations successfully")
+    void execute_ValidProject_AddsConfigurations() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.of("10.0.0"));
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).addJacksonDependency(mavenProject, mockLog);
+        verify(jakartaEeHelperMock).addMicroprofileOpenApiApiDependency(mavenProject, mockLog);
+        verify(jakartaEeHelperMock).addJakartaValidationApiDependency(mavenProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addHelperGenerateSource(mavenProject, mockLog);
+        
+        verify(openApiGeneratorHelperMock).processServer(mavenProject, tempFile, mockLog);
+
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when Jakarta EE version is missing")
+    void execute_MissingJakartaEeVersion_ThrowsException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/DataSourceUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/DataSourceUtilTest.java
@@ -1,0 +1,72 @@
+package com.apuntesdejava.jakartacoffeebuilder.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_ASADMIN;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_CLASS;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_WEB;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DataSourceUtilTest {
+
+    @Nested
+    @DisplayName("getPrefix")
+    class GetPrefix {
+
+        @Test
+        @DisplayName("should return java:global/jdbc/ for web.xml declaration")
+        void returnGlobalPrefixForWeb() {
+            assertEquals("java:global/jdbc/", DataSourceUtil.getPrefix(DATASOURCE_DECLARE_WEB));
+        }
+
+        @Test
+        @DisplayName("should return java:app/jdbc/ for class declaration")
+        void returnAppPrefixForClass() {
+            assertEquals("java:app/jdbc/", DataSourceUtil.getPrefix(DATASOURCE_DECLARE_CLASS));
+        }
+
+        @Test
+        @DisplayName("should return jdbc/ for unknown declaration")
+        void returnJdbcPrefixForUnknown() {
+            assertEquals("jdbc/", DataSourceUtil.getPrefix("unknown"));
+        }
+
+        @Test
+        @DisplayName("should return jdbc/ for asadmin declaration")
+        void returnJdbcPrefixForAsadmin() {
+            assertEquals("jdbc/", DataSourceUtil.getPrefix(DATASOURCE_DECLARE_ASADMIN));
+        }
+    }
+
+    @Nested
+    @DisplayName("validateDataSourceName")
+    class ValidateDataSourceName {
+
+        @Test
+        @DisplayName("should return fully qualified name for valid datasource name")
+        void returnsFullyQualifiedName() {
+            String result = DataSourceUtil.validateDataSourceName(DATASOURCE_DECLARE_WEB, "myDataSource");
+            assertEquals("java:global/jdbc/myDataSource", result);
+        }
+
+        @Test
+        @DisplayName("should accept name starting with letter and containing digits/underscores")
+        void acceptsValidNameWithDigitsAndUnderscores() {
+            String result = DataSourceUtil.validateDataSourceName(DATASOURCE_DECLARE_CLASS, "db_01_main");
+            assertEquals("java:app/jdbc/db_01_main", result);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"1invalid", "my-ds", "my ds", "ds@name", ""})
+        @DisplayName("should throw IllegalArgumentException for invalid names")
+        void throwsForInvalidName(String invalidName) {
+            assertThrows(IllegalArgumentException.class,
+                () -> DataSourceUtil.validateDataSourceName(DATASOURCE_DECLARE_WEB, invalidName));
+        }
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtilTest.java
@@ -1,11 +1,17 @@
 package com.apuntesdejava.jakartacoffeebuilder.util;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.function.Function;
 
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DEV_BASE_URL;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.PRD_BASE_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -26,5 +32,54 @@ public class HttpUtilTest {
 
         // Verify the result
         assertEquals("mocked response", result);
+    }
+
+    @Nested
+    @DisplayName("getUrl")
+    class GetUrl {
+
+        @AfterEach
+        void cleanUpSystemProperty() {
+            System.clearProperty("devel");
+        }
+
+        @Test
+        @DisplayName("should use PRD base URL when devel is false")
+        void usesPrdBaseUrlByDefault() {
+            System.setProperty("devel", "false");
+            String result = HttpUtil.getUrl("/dependencies.json");
+            assertTrue(result.startsWith(PRD_BASE_URL));
+            assertEquals(PRD_BASE_URL + "/dependencies.json", result);
+        }
+
+        @Test
+        @DisplayName("should use DEV base URL when devel is true")
+        void usesDevBaseUrlWhenDevelTrue() {
+            System.setProperty("devel", "true");
+            String result = HttpUtil.getUrl("/dependencies.json");
+            assertTrue(result.startsWith(DEV_BASE_URL));
+            assertEquals(DEV_BASE_URL + "/dependencies.json", result);
+        }
+
+        @Test
+        @DisplayName("should use PRD base URL when devel property is not set")
+        void usesPrdBaseUrlWhenPropertyNotSet() {
+            System.clearProperty("devel");
+            String result = HttpUtil.getUrl("/servers.json");
+            assertEquals(PRD_BASE_URL + "/servers.json", result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Parameter record")
+    class ParameterRecord {
+
+        @Test
+        @DisplayName("should store name and value")
+        void storesNameAndValue() {
+            HttpUtil.Parameter param = new HttpUtil.Parameter("key", "value");
+            assertEquals("key", param.name());
+            assertEquals("value", param.value());
+        }
     }
 }

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/MavenProjectUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/MavenProjectUtilTest.java
@@ -1,0 +1,228 @@
+package com.apuntesdejava.jakartacoffeebuilder.util;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MavenProjectUtilTest {
+
+    @Mock
+    private MavenProject mockProject;
+
+    @Nested
+    @DisplayName("getProjectPackage")
+    class GetProjectPackage {
+
+        @Test
+        @DisplayName("should derive package from groupId and artifactId")
+        void derivesPackageFromCoordinates() {
+            when(mockProject.getGroupId()).thenReturn("com.example");
+            when(mockProject.getArtifactId()).thenReturn("my-app");
+
+            String result = MavenProjectUtil.getProjectPackage(mockProject);
+
+            assertEquals("com.example.my.app", result);
+        }
+
+        @Test
+        @DisplayName("should replace non-alphanumeric characters with dots")
+        void replacesSpecialChars() {
+            when(mockProject.getGroupId()).thenReturn("com.apuntesdejava");
+            when(mockProject.getArtifactId()).thenReturn("jakarta-coffee-builder");
+
+            String result = MavenProjectUtil.getProjectPackage(mockProject);
+
+            assertEquals("com.apuntesdejava.jakarta.coffee.builder", result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Layer package methods")
+    class LayerPackages {
+
+        @BeforeEach
+        void setUp() {
+            when(mockProject.getGroupId()).thenReturn("com.example");
+            when(mockProject.getArtifactId()).thenReturn("myapp");
+        }
+
+        @Test
+        @DisplayName("getEntityPackage should append infrastructure.entity")
+        void entityPackage() {
+            assertEquals("com.example.myapp.infrastructure.entity",
+                MavenProjectUtil.getEntityPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getModelPackage should append domain.model")
+        void modelPackage() {
+            assertEquals("com.example.myapp.domain.model",
+                MavenProjectUtil.getModelPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getMapperPackage should append infrastructure.mapper")
+        void mapperPackage() {
+            assertEquals("com.example.myapp.infrastructure.mapper",
+                MavenProjectUtil.getMapperPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getServicePackage should append infrastructure.domain")
+        void servicePackage() {
+            assertEquals("com.example.myapp.infrastructure.domain",
+                MavenProjectUtil.getServicePackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getRepositoryPackage should append infrastructure.repository")
+        void repositoryPackage() {
+            assertEquals("com.example.myapp.infrastructure.repository",
+                MavenProjectUtil.getRepositoryPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getProviderPackage should append infrastructure.provider")
+        void providerPackage() {
+            assertEquals("com.example.myapp.infrastructure.provider",
+                MavenProjectUtil.getProviderPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getEnumsPackage should append enums")
+        void enumsPackage() {
+            assertEquals("com.example.myapp.enums",
+                MavenProjectUtil.getEnumsPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getFacesPackage should append app.faces")
+        void facesPackage() {
+            assertEquals("com.example.myapp.app.faces",
+                MavenProjectUtil.getFacesPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getApiResourcesPackage should append app.resources")
+        void apiResourcesPackage() {
+            assertEquals("com.example.myapp.app.resources",
+                MavenProjectUtil.getApiResourcesPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getDomainModelPackage should append domain.model")
+        void domainModelPackage() {
+            assertEquals("com.example.myapp.domain.model",
+                MavenProjectUtil.getDomainModelPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getModelRepositoryPackage should append domain.repository")
+        void modelRepositoryPackage() {
+            assertEquals("com.example.myapp.domain.repository",
+                MavenProjectUtil.getModelRepositoryPackage(mockProject));
+        }
+    }
+
+    @Nested
+    @DisplayName("getProfile")
+    class GetProfile {
+
+        @Test
+        @DisplayName("should return existing profile when found")
+        void returnsExistingProfile() {
+            var model = new Model();
+            var existingProfile = new Profile();
+            existingProfile.setId("test-profile");
+            model.addProfile(existingProfile);
+            when(mockProject.getOriginalModel()).thenReturn(model);
+
+            Profile result = MavenProjectUtil.getProfile(mockProject, "test-profile");
+
+            assertSame(existingProfile, result);
+        }
+
+        @Test
+        @DisplayName("should create and return new profile when not found")
+        void createsNewProfile() {
+            var model = new Model();
+            when(mockProject.getOriginalModel()).thenReturn(model);
+
+            Profile result = MavenProjectUtil.getProfile(mockProject, "new-profile");
+
+            assertEquals("new-profile", result.getId());
+            assertEquals(1, model.getProfiles().size());
+        }
+    }
+
+    @Nested
+    @DisplayName("getParent")
+    class GetParent {
+
+        @Test
+        @DisplayName("should return parent path of POM file")
+        void returnsParentPath() {
+            File pomFile = new File("/projects/my-app/pom.xml");
+            when(mockProject.getFile()).thenReturn(pomFile);
+
+            Path result = MavenProjectUtil.getParent(mockProject);
+
+            assertEquals(pomFile.toPath().getParent(), result);
+        }
+    }
+
+    @Nested
+    @DisplayName("getBuild")
+    class GetBuild {
+
+        @Test
+        @DisplayName("should return existing build from profile")
+        void returnsExistingBuild() {
+            var model = new Model();
+            var profile = new Profile();
+            profile.setId("some-profile");
+            var build = new Build();
+            build.setPlugins(new ArrayList<>());
+            profile.setBuild(build);
+            model.addProfile(profile);
+            when(mockProject.getOriginalModel()).thenReturn(model);
+
+            var result = MavenProjectUtil.getBuild(mockProject, "some-profile");
+
+            assertSame(build, result);
+        }
+
+        @Test
+        @DisplayName("should create new build when profile has none")
+        void createsNewBuild() {
+            var model = new Model();
+            var profile = new Profile();
+            profile.setId("empty-profile");
+            model.addProfile(profile);
+            when(mockProject.getOriginalModel()).thenReturn(model);
+
+            var result = MavenProjectUtil.getBuild(mockProject, "empty-profile");
+
+            assertNotNull(result);
+            assertNotNull(result.getPlugins());
+        }
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/StringsUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/StringsUtilTest.java
@@ -1,0 +1,208 @@
+package com.apuntesdejava.jakartacoffeebuilder.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StringsUtilTest {
+
+    @Nested
+    @DisplayName("removeCharacterRoot")
+    class RemoveCharacterRoot {
+
+        @Test
+        @DisplayName("should remove leading slash")
+        void removesLeadingSlash() {
+            assertEquals("path/to/file", StringsUtil.removeCharacterRoot("/path/to/file"));
+        }
+
+        @Test
+        @DisplayName("should return path unchanged when no leading slash")
+        void returnsUnchangedWhenNoLeadingSlash() {
+            assertEquals("path/to/file", StringsUtil.removeCharacterRoot("path/to/file"));
+        }
+
+        @Test
+        @DisplayName("should handle single slash")
+        void handlesSingleSlash() {
+            assertEquals("", StringsUtil.removeCharacterRoot("/"));
+        }
+
+        @Test
+        @DisplayName("should handle empty string")
+        void handlesEmptyString() {
+            assertEquals("", StringsUtil.removeCharacterRoot(""));
+        }
+    }
+
+    @Nested
+    @DisplayName("toPascalCase")
+    class ToPascalCase {
+
+        @ParameterizedTest
+        @CsvSource({
+            "hello-world, HelloWorld",
+            "my_class_name, MyClassName",
+            "simple, Simple",
+            "already-Pascal, AlreadyPascal",
+            "one.two.three, OneTwoThree"
+        })
+        @DisplayName("should convert delimited strings to PascalCase")
+        void convertsToPascalCase(String input, String expected) {
+            assertEquals(expected, StringsUtil.toPascalCase(input));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   ", "  \t "})
+        @DisplayName("should return empty for null, blank, or empty input")
+        void returnsEmptyForBlankInput(String input) {
+            assertEquals("", StringsUtil.toPascalCase(input));
+        }
+
+        @Test
+        @DisplayName("should handle string with only special characters")
+        void handlesOnlySpecialChars() {
+            assertEquals("", StringsUtil.toPascalCase("---"));
+        }
+    }
+
+    @Nested
+    @DisplayName("camelCaseToParamCase")
+    class CamelCaseToParamCase {
+
+        @ParameterizedTest
+        @CsvSource({
+            "camelCase, camel-case",
+            "myVariableName, my-variable-name",
+            "simple, simple",
+            "HTMLParser, html-parser"
+        })
+        @DisplayName("should convert camelCase to param-case")
+        void convertsCorrectly(String input, String expected) {
+            assertEquals(expected, StringsUtil.camelCaseToParamCase(input));
+        }
+    }
+
+    @Nested
+    @DisplayName("containsIgnoreCase")
+    class ContainsIgnoreCase {
+
+        @Test
+        @DisplayName("should return true when set contains value (same case)")
+        void returnsTrueForSameCase() {
+            assertTrue(StringsUtil.containsIgnoreCase(Set.of("Hello", "World"), "Hello"));
+        }
+
+        @Test
+        @DisplayName("should return true when set contains value (different case)")
+        void returnsTrueForDifferentCase() {
+            assertTrue(StringsUtil.containsIgnoreCase(Set.of("Hello", "World"), "hello"));
+        }
+
+        @Test
+        @DisplayName("should return false when set does not contain value")
+        void returnsFalseWhenNotFound() {
+            assertFalse(StringsUtil.containsIgnoreCase(Set.of("Hello", "World"), "Foo"));
+        }
+    }
+
+    @Nested
+    @DisplayName("containsAnyIgnoreCase")
+    class ContainsAnyIgnoreCase {
+
+        @Test
+        @DisplayName("should return true when any element matches")
+        void returnsTrueWhenAnyMatches() {
+            assertTrue(StringsUtil.containsAnyIgnoreCase(
+                Set.of("Hello", "World"),
+                Set.of("world", "foo")));
+        }
+
+        @Test
+        @DisplayName("should return false when no element matches")
+        void returnsFalseWhenNoneMatches() {
+            assertFalse(StringsUtil.containsAnyIgnoreCase(
+                Set.of("Hello", "World"),
+                Set.of("foo", "bar")));
+        }
+    }
+
+    @Nested
+    @DisplayName("findIgnoreCase(Set, Set)")
+    class FindIgnoreCaseSet {
+
+        @Test
+        @DisplayName("should find matching entries ignoring case")
+        void findsMatchingEntries() {
+            Collection<String> result = StringsUtil.findIgnoreCase(
+                Set.of("Column", "JoinColumn", "ManyToOne"),
+                Set.of("column", "manytoone"));
+            assertEquals(2, result.size());
+            assertTrue(result.contains("Column"));
+            assertTrue(result.contains("ManyToOne"));
+        }
+
+        @Test
+        @DisplayName("should return empty when no match found")
+        void returnsEmptyWhenNoMatch() {
+            Collection<String> result = StringsUtil.findIgnoreCase(
+                Set.of("Column", "JoinColumn"),
+                Set.of("foo", "bar"));
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("findIgnoreCase(Set, String)")
+    class FindIgnoreCaseString {
+
+        @Test
+        @DisplayName("should return matching string ignoring case")
+        void returnsMatchingString() {
+            String result = StringsUtil.findIgnoreCase(Set.of("Column", "JoinColumn"), "column");
+            assertEquals("Column", result);
+        }
+
+        @Test
+        @DisplayName("should return null when no match found")
+        void returnsNullWhenNotFound() {
+            assertNull(StringsUtil.findIgnoreCase(Set.of("Column", "JoinColumn"), "foo"));
+        }
+    }
+
+    @Nested
+    @DisplayName("findIgnoreCaseOptional")
+    class FindIgnoreCaseOptional {
+
+        @Test
+        @DisplayName("should return Optional with value when found")
+        void returnsOptionalWithValue() {
+            Optional<String> result = StringsUtil.findIgnoreCaseOptional(
+                Set.of("Column", "JoinColumn"), "joincolumn");
+            assertTrue(result.isPresent());
+            assertEquals("JoinColumn", result.get());
+        }
+
+        @Test
+        @DisplayName("should return empty Optional when not found")
+        void returnsEmptyOptional() {
+            Optional<String> result = StringsUtil.findIgnoreCaseOptional(
+                Set.of("Column", "JoinColumn"), "foo");
+            assertTrue(result.isEmpty());
+        }
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/XmlUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/XmlUtilTest.java
@@ -1,4 +1,401 @@
 package com.apuntesdejava.jakartacoffeebuilder.util;
 
-public class XmlUtilTest {
+import org.apache.maven.plugin.logging.Log;
+import org.dom4j.Document;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.Namespace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class XmlUtilTest {
+
+    private XmlUtil xmlUtil;
+    private Log mockLog;
+
+    @BeforeEach
+    void setUp() {
+        xmlUtil = XmlUtil.getInstance();
+        mockLog = mock(Log.class);
+    }
+
+    @Test
+    @DisplayName("getInstance: should return the same singleton instance")
+    void instanceIsSingleton() {
+        assertSame(XmlUtil.getInstance(), XmlUtil.getInstance());
+    }
+
+    @Nested
+    @DisplayName("addElement(parent, tagName, content)")
+    class AddElementWithContent {
+
+        @Test
+        @DisplayName("should add child element with text content")
+        void addsChildWithText() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+
+            xmlUtil.addElement(root, "child", "hello");
+
+            Element child = root.element("child");
+            assertNotNull(child);
+            assertEquals("hello", child.getText());
+        }
+    }
+
+    @Nested
+    @DisplayName("addElement(parent, tagName)")
+    class AddElementSimple {
+
+        @Test
+        @DisplayName("should add empty child element")
+        void addsEmptyChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+
+            Element result = xmlUtil.addElement(root, "child");
+
+            assertNotNull(result);
+            assertEquals("child", result.getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("addElement(parent, tagName, attributes)")
+    class AddElementWithAttributes {
+
+        @Test
+        @DisplayName("should add element with attributes")
+        void addsElementWithAttributes() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Map<String, String> attrs = new LinkedHashMap<>();
+            attrs.put("name", "test");
+            attrs.put("value", "123");
+
+            Element result = xmlUtil.addElement(root, "param", attrs);
+
+            // When element is new, result is the new element
+            Element param = root.element("param");
+            assertNotNull(param);
+            assertEquals("test", param.attributeValue("name"));
+            assertEquals("123", param.attributeValue("value"));
+        }
+
+        @Test
+        @DisplayName("should not add duplicate element with same attributes")
+        void skipsDuplicateElement() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Map<String, String> attrs = new LinkedHashMap<>();
+            attrs.put("name", "test");
+
+            xmlUtil.addElement(root, "param", attrs);
+            xmlUtil.addElement(root, "param", attrs); // duplicate
+
+            assertEquals(1, root.elements("param").size());
+        }
+    }
+
+    @Nested
+    @DisplayName("addElement(parent, tagName, namespace)")
+    class AddElementWithNamespace {
+
+        @Test
+        @DisplayName("should add element with namespace")
+        void addsElementWithNamespace() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Namespace ns = new Namespace("ns", "http://example.com/ns");
+
+            Element result = xmlUtil.addElement(root, "child", ns);
+
+            assertNotNull(result);
+            assertEquals("child", result.getName());
+            assertEquals("http://example.com/ns", result.getNamespaceURI());
+        }
+    }
+
+    @Nested
+    @DisplayName("findElements")
+    class FindElements {
+
+        @Test
+        @DisplayName("should find elements by XPath expression")
+        void findsElementsByXpath() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            root.addElement("item").setText("a");
+            root.addElement("item").setText("b");
+
+            Stream<Element> result = xmlUtil.findElements(doc, "//item");
+
+            assertEquals(2, result.count());
+        }
+
+        @Test
+        @DisplayName("should return empty stream when no elements match")
+        void returnsEmptyForNoMatch() {
+            Document doc = DocumentHelper.createDocument();
+            doc.addElement("root");
+
+            Stream<Element> result = xmlUtil.findElements(doc, "//nonexistent");
+
+            assertEquals(0, result.count());
+        }
+
+        @Test
+        @DisplayName("should throw NullPointerException for null document")
+        void throwsForNullDocument() {
+            assertThrows(NullPointerException.class,
+                () -> xmlUtil.findElements(null, "//test", Map.of()));
+        }
+    }
+
+    @Nested
+    @DisplayName("getElement")
+    class GetElement {
+
+        @Test
+        @DisplayName("should return existing child element")
+        void returnsExistingChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Element existing = root.addElement("child");
+            existing.setText("value");
+
+            var result = xmlUtil.getElement(root, "child");
+
+            assertTrue(result.isPresent());
+            assertEquals("value", result.get().getText());
+        }
+
+        @Test
+        @DisplayName("should create and return new element when not found")
+        void createsNewElement() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+
+            var result = xmlUtil.getElement(root, "newChild");
+
+            assertTrue(result.isPresent());
+            assertEquals("newChild", result.get().getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("getElement(parent, name, namespace)")
+    class GetElementWithNamespace {
+
+        @Test
+        @DisplayName("should return existing element with namespace")
+        void returnsExistingNamespacedElement() {
+            Document doc = DocumentHelper.createDocument();
+            Namespace ns = new Namespace("ns", "http://example.com");
+            Element root = doc.addElement("root");
+            root.addElement(org.dom4j.QName.get("child", ns)).setText("found");
+
+            var result = xmlUtil.getElement(root, "child", ns);
+
+            assertTrue(result.isPresent());
+            assertEquals("found", result.get().getText());
+        }
+
+        @Test
+        @DisplayName("should create new namespaced element when not found")
+        void createsNewNamespacedElement() {
+            Document doc = DocumentHelper.createDocument();
+            Namespace ns = new Namespace("ns", "http://example.com");
+            Element root = doc.addElement("root");
+
+            var result = xmlUtil.getElement(root, "newChild", ns);
+
+            assertTrue(result.isPresent());
+            assertEquals("newChild", result.get().getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("removeElement")
+    class RemoveElement {
+
+        @Test
+        @DisplayName("should remove existing child element")
+        void removesChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            root.addElement("toRemove");
+
+            xmlUtil.removeElement(root, "toRemove");
+
+            assertNull(root.element("toRemove"));
+        }
+
+        @Test
+        @DisplayName("should do nothing when element to remove does not exist")
+        void doesNothingWhenNotFound() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+
+            assertDoesNotThrow(() -> xmlUtil.removeElement(root, "nonexistent"));
+        }
+    }
+
+    @Nested
+    @DisplayName("removeElement(element, tagName, namespace)")
+    class RemoveElementWithNamespace {
+
+        @Test
+        @DisplayName("should remove namespaced child element")
+        void removesNamespacedChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Namespace ns = new Namespace("ns", "http://example.com");
+            root.addElement(org.dom4j.QName.get("child", ns));
+
+            xmlUtil.removeElement(root, "child", ns);
+
+            assertNull(root.element(org.dom4j.QName.get("child", ns)));
+        }
+    }
+
+    @Nested
+    @DisplayName("addElementAsFirstChild")
+    class AddElementAsFirstChild {
+
+        @Test
+        @DisplayName("should add element as first child")
+        void addsAsFirstChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            root.addElement("existing");
+
+            Element result = xmlUtil.addElementAsFirstChild(root, "first", "value");
+
+            assertEquals("first", result.getName());
+            assertEquals("value", result.getText());
+            // Verify it's the first content element
+            Element firstElement = (Element) root.content().getFirst();
+            assertEquals("first", firstElement.getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("saveDocument")
+    class SaveDocument {
+
+        @Test
+        @DisplayName("should save document to file")
+        void savesDocumentToFile(@TempDir Path tempDir) throws IOException {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            root.addElement("child").setText("value");
+
+            Path xmlFile = tempDir.resolve("test.xml");
+            xmlUtil.saveDocument(doc, mockLog, xmlFile);
+
+            assertTrue(Files.exists(xmlFile));
+            String content = Files.readString(xmlFile);
+            assertTrue(content.contains("<root>"));
+            assertTrue(content.contains("<child>value</child>"));
+        }
+
+        @Test
+        @DisplayName("should handle null document gracefully")
+        void handlesNullDocument(@TempDir Path tempDir) {
+            Path xmlFile = tempDir.resolve("test.xml");
+            assertDoesNotThrow(() -> xmlUtil.saveDocument(null, mockLog, xmlFile));
+            assertFalse(Files.exists(xmlFile));
+        }
+    }
+
+    @Nested
+    @DisplayName("getDocument")
+    class GetDocument {
+
+        @Test
+        @DisplayName("should read existing XML file")
+        void readsExistingFile(@TempDir Path tempDir) throws IOException {
+            Path xmlFile = tempDir.resolve("existing.xml");
+            Files.writeString(xmlFile, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root><child>test</child></root>");
+
+            var result = xmlUtil.getDocument(mockLog, xmlFile);
+
+            assertTrue(result.isPresent());
+            assertNotNull(result.get().getRootElement());
+            assertEquals("root", result.get().getRootElement().getName());
+        }
+
+        @Test
+        @DisplayName("should return empty Optional for non-existing file")
+        void returnsEmptyForMissingFile(@TempDir Path tempDir) {
+            Path nonExistingFile = tempDir.resolve("missing.xml");
+
+            var result = xmlUtil.getDocument(mockLog, nonExistingFile);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("should create new document with postCreate when file does not exist")
+        void createsNewDocumentWithPostCreate(@TempDir Path tempDir) {
+            Path newFile = tempDir.resolve("subdir/new.xml");
+
+            var result = xmlUtil.getDocument(mockLog, newFile,
+                doc -> doc.addElement("newRoot"));
+
+            assertTrue(result.isPresent());
+            assertEquals("newRoot", result.get().getRootElement().getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("addElement(document, log, parentNode, nodeName, postCreate)")
+    class AddElementToDocument {
+
+        @Test
+        @DisplayName("should add element to document node found by XPath")
+        void addsElementToDocumentNode() {
+            Document doc = DocumentHelper.createDocument();
+            doc.addElement("root");
+
+            Element result = xmlUtil.addElement(doc, mockLog, "//root", "child",
+                elem -> elem.setText("created"));
+
+            assertNotNull(result);
+            assertEquals("child", result.getName());
+            assertEquals("created", result.getText());
+        }
+
+        @Test
+        @DisplayName("should return null when parent node not found")
+        void returnsNullWhenParentNotFound() {
+            Document doc = DocumentHelper.createDocument();
+            doc.addElement("root");
+
+            Element result = xmlUtil.addElement(doc, mockLog, "//nonexistent", "child", null);
+
+            assertNull(result);
+        }
+    }
 }


### PR DESCRIPTION
# Pull Request Description: Feature/90 - Create DataSource for Payara

## Overview
This Pull Request introduces comprehensive support for DataSource management specifically tailored for Payara Server/Micro, utilizing `asadmin` configurations. It also includes several architectural improvements to utility classes, dependency management, and testing infrastructure.

## Key Changes

### 1. Payara DataSource Support
*   **DataSource Creator Factory:** Implemented a new factory pattern to handle `asadmin` declarations for data source creation.
*   **Profile Support:** Added support for different profiles in DataSource handling to allow environment-specific configurations.
*   **Asadmin Command Optimization:** Improved command-line option generation for `asadmin` configurations to ensure better compatibility with Payara.

### 2. Utility & Infrastructure Enhancements
*   **JSON & HTTP Utilities:** Refactored `JsonUtil` and `HttpUtil` to optimize `JsonValue` handling and streamline HTTP client execution.
*   **Exception Handling:** Introduced robust exception handling across the new data source creation flow.
*   **Constants Management:** Introduced a centralized constants utility to improve code maintainability and reduce magic strings.

### 3. Dependency & Project Configuration
*   **Maven Plugin Updates:** Enhanced dependency management for Jackson and Payara Micro plugins within the `pom.xml`.
*   **Dependency Alignment:** Updated several project dependencies and plugin versions to improve stability and keep the project up to date with modern Jakarta EE standards.

### 4. Quality Assurance
*   **Unit Testing:** Introduced extensive unit tests covering the new DataSource creation logic and factory patterns.
*   **Refactoring:** Simplified template formatting in `AbstractModelRepository` and streamlined entity-related logic within the persistence helpers.

## Impact
These changes allow the `jakarta-coffee-builder-plugin` to automatically configure and deploy DataSources to Payara environments, significantly reducing manual configuration steps for developers using this server.