### PR TITLE
Prepare Jakarta Coffee Builder plugin 0.0.6 release updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ replay_pid*
 .idea
 target
 /nbactions.xml
+.agent
+*-REPORT.MD
+**/*.log

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ mvn com.apuntesdejava:jakarta-coffee-builder-plugin:<goal> -D<opcion>=<valor>
 
 ---
 
+## 🗄️ Persistencia y Datos
+
+### `add-persistence`
+Configura la unidad de persistencia (JPA).
+- **`-Dpersistence-unit-name=<nombre>`**: Nombre de la Persistence Unit. (Por defecto: `defaultPU`)
+- **`-Ddatasource-name=<nombre>`**: Nombre JNDI del Data Source. (Por defecto: `defaultDatasource`)
+- **`-Durl=<jdbc-url>`**: URL de conexión JDBC. (Por defecto: H2 in-memory)
+- **`-Duser=<usuario>`**: Usuario de base de datos.
+- **`-Dpassword=<clave>`**: Contraseña de base de datos.
+- **`-Ddeclare=<web|...>`**: Lugar donde declarar el recurso (Por defecto: `web`).
+
+### `add-datasource`
+Agrega la configuración de un Data Source.
+- *(Mismas opciones que `add-persistence`)*.
+
+### `add-entities`
+Integra definiciones de entidades JPA en el proyecto.
+- **`-Dentities-file=<path>`**: Ruta al archivo de definición de entidades. (**Requerido**)
+
+---
+
 ## 🏗️ Arquitectura y Scaffolding
 
 ### `add-domain-models`
@@ -46,26 +67,6 @@ Genera formularios CRUD de JSF/PrimeFaces a partir de entidades.
 - **`-Dforms-file=<path>`**: Ruta al JSON de definición de formularios. (**Requerido**)
 - **`-Dentities-file=<path>`**: Ruta al JSON de definición de entidades. (**Requerido**)
 
----
-
-## 🗄️ Persistencia y Datos
-
-### `add-persistence`
-Configura la unidad de persistencia (JPA).
-- **`-Dpersistence-unit-name=<nombre>`**: Nombre de la Persistence Unit. (Por defecto: `defaultPU`)
-- **`-Ddatasource-name=<nombre>`**: Nombre JNDI del Data Source. (Por defecto: `defaultDatasource`)
-- **`-Durl=<jdbc-url>`**: URL de conexión JDBC. (Por defecto: H2 in-memory)
-- **`-Duser=<usuario>`**: Usuario de base de datos.
-- **`-Dpassword=<clave>`**: Contraseña de base de datos.
-- **`-Ddeclare=<web|...>`**: Lugar donde declarar el recurso (Por defecto: `web`).
-
-### `add-datasource`
-Agrega la configuración de un Data Source.
-- *(Mismas opciones que `add-persistence`)*.
-
-### `add-entities`
-Integra definiciones de entidades JPA en el proyecto.
-- **`-Dentities-file=<path>`**: Ruta al archivo de definición de entidades. (**Requerido**)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,22 +66,7 @@ Crea un nuevo template Facelet.
 Genera formularios CRUD de JSF/PrimeFaces a partir de entidades.
 - **`-Dforms-file=<path>`**: Ruta al JSON de definición de formularios. (**Requerido**)
 - **`-Dentities-file=<path>`**: Ruta al JSON de definición de entidades. (**Requerido**)
-
-
----
-
-## 🚀 Servidores de Aplicación y Microservicios
-
-### `add-glassfish-embedded`
-Configura un perfil de Maven para ejecutar con GlassFish Embedded.
-- **`-Dprofile=<nombre>`**: ID del perfil de Maven a crear. (Por defecto: `glassfish`)
-- **`-Dport=<puerto>`**: Puerto HTTP. (Por defecto: `8080`)
-- **`-DcontextRoot=<ruta>`**: Context root de la aplicación. (Por defecto: `${project.build.finalName}`)
-
-### `add-payaramicro`
-Configura el plugin y perfil para Payara Micro.
-- **`-Dprofile=<nombre>`**: ID del perfil de Maven a crear. (Por defecto: `payaramicro`)
-
+ 
 ---
 
 ## 🛠️ Utilidades
@@ -89,10 +74,3 @@ Configura el plugin y perfil para Payara Micro.
 ### `add-validation-api`
 Agrega las dependencias de Jakarta Validation API para habilitar validaciones mediante anotaciones (`@NotNull`, `@Size`, etc.).
 
----
-
-## 📝 Ejemplo Completo
-Para agregar una página de login utilizando un template existente y sin crear un backing bean:
-```bash
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:add-face-page -Dname=login -Dtemplate=mainTemplate -Dmanaged-bean=false
-```

--- a/README.md
+++ b/README.md
@@ -1,309 +1,97 @@
 # Jakarta Coffee Builder Plugin
-![Maven Central Version](https://img.shields.io/maven-central/v/com.apuntesdejava/jakarta-coffee-builder-plugin)  ![GitHub last commit](https://img.shields.io/github/last-commit/jakarta-coffee-builder/jakarta-coffee-builder-plugin)  [![GitHub](https://img.shields.io/badge/maven-plugin-darkgreen?logo=github)](https://github.com/jakarta-coffee-builder/jakarta-coffee-builder-plugin)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/jakarta-coffee-builder/jakarta-coffee-builder-plugin/maven-ci-cd.yml)
 
-`develop`: ![GitHub branch check runs](https://img.shields.io/github/check-runs/jakarta-coffee-builder/jakarta-coffee-builder-plugin/develop) ![GitHub commit activity (branch)](https://img.shields.io/github/commit-activity/m/jakarta-coffee-builder/jakarta-coffee-builder-plugin/develop)
+Este plugin de Maven automatiza la configuración y el andamiaje (scaffolding) de proyectos Jakarta EE, facilitando la adopción de mejores prácticas y acelerando el desarrollo inicial.
 
+## 🚀 Uso desde la Línea de Comandos
 
-Maven plugin for adding and modifying Jakarta EE functionality to a project.
+Todos los "goals" del plugin pueden ejecutarse directamente sin necesidad de estar configurados en el `pom.xml`, utilizando la siguiente sintaxis:
 
-# Goals
-
-## Jakarta Faces
-
-### Add Jakarta Faces Configuration
-
-Add Jakarta Faces Servlet configuration in `web.xml` file
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-faces 
+```bash
+mvn com.apuntesdejava:jakarta-coffee-builder-plugin:<goal> -D<opcion>=<valor>
 ```
 
-**Result**
+---
 
-```java
-package com.application.app.faces;
+## 🏗️ Arquitectura y Scaffolding
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.faces.annotation.FacesConfig;
+### `add-domain-models`
+Genera capas de arquitectura (DTOs, Mappers, Repositorios y Servicios) basándose en una definición de entidades.
+- **`-Dentities-file=<path>`**: Ruta al archivo JSON con la definición de entidades. (**Requerido**)
 
-@FacesConfig
-@ApplicationScoped
-public class FacesConfiguration {
+### `create-openapi`
+Genera el código del lado del servidor (server-side) a partir de una especificación OpenAPI.
+- **`-Dopenapi-server=<path>`**: Ruta al archivo OpenAPI (yml/json). (Por defecto: `${project.basedir}/openapi.yml`)
 
-}
+---
+
+## 🎨 Jakarta Faces (JSF)
+
+### `add-faces`
+Configura Jakarta Faces en el proyecto (dependencias y declaración en `web.xml`).
+- **`-Dwelcome-file=<nombre>`**: Nombre del archivo de bienvenida. (Por defecto: `index.xhtml`)
+
+### `add-face-page`
+Agrega una nueva página JSF al proyecto.
+- **`-Dname=<nombre>`**: Nombre de la página (sin extensión). (**Requerido**)
+- **`-Dmanaged-bean=<true|false>`**: Indica si se debe crear un backing bean asociado. (Por defecto: `true`)
+- **`-Dtemplate=<nombre>`**: (Opcional) Nombre del template Facelet a utilizar.
+
+### `add-face-template`
+Crea un nuevo template Facelet.
+- **`-Dname=<nombre>`**: Nombre del template. (**Requerido**)
+- **`-Dinserts=<lista>`**: Lista separada por comas de nombres para los `ui:insert`.
+
+### `add-forms-from-entities`
+Genera formularios CRUD de JSF/PrimeFaces a partir de entidades.
+- **`-Dforms-file=<path>`**: Ruta al JSON de definición de formularios. (**Requerido**)
+- **`-Dentities-file=<path>`**: Ruta al JSON de definición de entidades. (**Requerido**)
+
+---
+
+## 🗄️ Persistencia y Datos
+
+### `add-persistence`
+Configura la unidad de persistencia (JPA).
+- **`-Dpersistence-unit-name=<nombre>`**: Nombre de la Persistence Unit. (Por defecto: `defaultPU`)
+- **`-Ddatasource-name=<nombre>`**: Nombre JNDI del Data Source. (Por defecto: `defaultDatasource`)
+- **`-Durl=<jdbc-url>`**: URL de conexión JDBC. (Por defecto: H2 in-memory)
+- **`-Duser=<usuario>`**: Usuario de base de datos.
+- **`-Dpassword=<clave>`**: Contraseña de base de datos.
+- **`-Ddeclare=<web|...>`**: Lugar donde declarar el recurso (Por defecto: `web`).
+
+### `add-datasource`
+Agrega la configuración de un Data Source.
+- *(Mismas opciones que `add-persistence`)*.
+
+### `add-entities`
+Integra definiciones de entidades JPA en el proyecto.
+- **`-Dentities-file=<path>`**: Ruta al archivo de definición de entidades. (**Requerido**)
+
+---
+
+## 🚀 Servidores de Aplicación y Microservicios
+
+### `add-glassfish-embedded`
+Configura un perfil de Maven para ejecutar con GlassFish Embedded.
+- **`-Dprofile=<nombre>`**: ID del perfil de Maven a crear. (Por defecto: `glassfish`)
+- **`-Dport=<puerto>`**: Puerto HTTP. (Por defecto: `8080`)
+- **`-DcontextRoot=<ruta>`**: Context root de la aplicación. (Por defecto: `${project.build.finalName}`)
+
+### `add-payaramicro`
+Configura el plugin y perfil para Payara Micro.
+- **`-Dprofile=<nombre>`**: ID del perfil de Maven a crear. (Por defecto: `payaramicro`)
+
+---
+
+## 🛠️ Utilidades
+
+### `add-validation-api`
+Agrega las dependencias de Jakarta Validation API para habilitar validaciones mediante anotaciones (`@NotNull`, `@Size`, etc.).
+
+---
+
+## 📝 Ejemplo Completo
+Para agregar una página de login utilizando un template existente y sin crear un backing bean:
+```bash
+mvn com.apuntesdejava:jakarta-coffee-builder-plugin:add-face-page -Dname=login -Dtemplate=mainTemplate -Dmanaged-bean=false
 ```
-
-**Showing**
-[![asciicast](https://asciinema.org/a/30Zyd628az3toF03XtZ5eSLRc.svg)](https://asciinema.org/a/30Zyd628az3toF03XtZ5eSLRc)
-
-### Add Jakarta Facelet Page (Template)
-
-Add a Facelet page
-
-```shell
-mvn "com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-template" 
-```
-
-**Parameters**
-
-| Parameter | Definition                     | Example                        |
-|-----------|--------------------------------|--------------------------------|
-| `name`    | Name of the Template to create | `/WEB-INF/templates/template1` |
-| `inserts` | Names of inserts block names   | `section1,section2,section3`   |
-
-
-
-**Example**
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-template \
-    -Dname=/WEB-INF/template/main.xhtml \
-    -Dinserts=header,body,footer
-```
-**Showing**
-[![asciicast](https://asciinema.org/a/tD2VpNkH5EHSQaTYRu9pasArc.svg)](https://asciinema.org/a/tD2VpNkH5EHSQaTYRu9pasArc)
-
-### Add Jakarta Faces Page
-
-Add a Face page, associating it with a Managed Bean. It can also be done by using a specified Facelet template
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-page
-```
-
-**Parameters**
-
-| Parameter      | Definition                                                                                            | Default value | Example                        |
-|----------------|-------------------------------------------------------------------------------------------------------|---------------|--------------------------------|
-| `name`         | Name of the Face page to create                                                                       |               |                                |
-| `managed-bean` | Boolean value indicating whether or not the Managed Bean class associated with the Face is created.   | `true`        |                                |
-| `template`     | Path of the Facelet template to be implemented for the Face to be created. This parameter is optional |               | `/WEB-INF/templates/template1` |
-
-
-
-**Example**
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-page \
-    -Dname=hello-world \
-    -Dmanaged-bean=false
-
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-face-page \
-    -Dname=persons \
-    -Dmanaged-bean=true
-
-```
-
-**Showing**
-
-Creating page with / without Managed Bean:
-[![asciicast](https://asciinema.org/a/And0N0LueNSaMCKV9VnyKm1gr.svg)](https://asciinema.org/a/And0N0LueNSaMCKV9VnyKm1gr)
-
-
-## Jakarta Persistence
-
-### Add Jakarta Persistence Configuration
-
-Add Jakarta Persistence configuration in `persistence.xml` file
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-persistence
-```
-
-**Parameters**
-
-| Parameter               | Definition                                                                                                             | Default value       |
-|-------------------------|------------------------------------------------------------------------------------------------------------------------|---------------------|
-| `datasource-name`       | This parameter defines the JNDI name of the DataSource. This value will be included in the DataSource configuration.   | `defaultDatasource` |
-| `url`                   | This parameter defines the URL of the DataSource. This value will be included in the DataSource configuration.         |                     |
-| `username`              | This parameter defines the username of the DataSource. This value will be included in the DataSource configuration.    |                     |
-| `password`              | This parameter defines the password of the DataSource. This value will be included in the DataSource configuration.    |                     |
-| `declare`               | Indicates how the DataSource is to be declared in the application. Possible values are `web.xml` `class`               | `class`             |
-| `server-name`           | This parameter defines the server name of the DataSource. This value will be included in the DataSource configuration. |                     |
-| `port-number`           | This parameter defines the port number of the DataSource. This value will be included in the DataSource configuration. |                     |
-| `properties`            | This parameter defines the properties of the DataSource. This value will be included in the DataSource configuration.  |                     |
-| `persistence-unit-name` | This parameter defines the name of the persistence unit. This value will be included in the persistence configuration. |                     | 
-
-
-### Add DataSource configuration
-
-Add DataSource configuration
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-datasource
-```
-
-**Parameters**
-
-| Parameter               | Definition                                                                                                             | Default value       |
-|-------------------------|------------------------------------------------------------------------------------------------------------------------|---------------------|
-| `datasource-name`       | This parameter defines the JNDI name of the DataSource. This value will be included in the DataSource configuration.   | `defaultDatasource` |
-| `url`                   | This parameter defines the URL of the DataSource. This value will be included in the DataSource configuration.         |                     |
-| `username`              | This parameter defines the username of the DataSource. This value will be included in the DataSource configuration.    |                     |
-| `password`              | This parameter defines the password of the DataSource. This value will be included in the DataSource configuration.    |                     |
-| `declare`               | Indicates how the DataSource is to be declared in the application. Possible values are `web.xml` `class`               | `class`             |
-| `server-name`           | This parameter defines the server name of the DataSource. This value will be included in the DataSource configuration. |                     |
-| `port-number`           | This parameter defines the port number of the DataSource. This value will be included in the DataSource configuration. |                     |
-| `properties`            | This parameter defines the properties of the DataSource. This value will be included in the DataSource configuration.  |                     |
-| `persistence-unit-name` | This parameter defines the name of the persistence unit. This value will be included in the persistence configuration. |                     | 
-
-
-### Add Jakarta Persistence Entity
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-entities
-
-```
-
-**Parameters**
-
-| Parameter       | Definition                                                                                        | Example                                 |
-|-----------------|---------------------------------------------------------------------------------------------------|-----------------------------------------|
-| `entities-file` | The name of the json file that contains the list of entities and their definitions to be created. | [entities.json](examples/entities.json) |
-
-**Example JSON File**
-```json
-{
-  "Category": {
-    "fields": {
-      "id": {
-        "type": "UUID",
-        "isId": true,
-        "generatedValue": "UUID"
-      },
-      "name": {
-        "type": "String",
-        "column": {
-          "length": 100
-        }
-      }
-    }
-  },
-  "Pet": {
-    "fields": {
-      "id": {
-        "type": "Long",
-        "isId": true,
-        "generatedValue": "Identity"
-      },
-      "category": {
-        "type": "Category",
-        "manyToOne": true,
-        "joinColumn": {
-          "name": "category_id",
-          "nullable": false
-        }
-      },
-      "name": {
-        "type": "String",
-        "column": {
-          "length": 100
-        }
-      },
-      "status": {
-        "type": "String"
-      }
-    }
-  } 
-}
-```
-
-
-## Jakarta RESTful Web Services
-
-### Create REST services with OpenAPI specifications
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:create-openapi
-```
-
-**Parameters**
-
-| Parameter        | Definition                                                                        | Example                               |
-|------------------|-----------------------------------------------------------------------------------|---------------------------------------|
-| `openapi-server` | The name of the yml file is specified with the server-side OpenAPI specification. | [openapi.yaml](examples/openapi.yaml) |
-
-**Note**
-- Each endpoint must be identified by a label
-
-### Add Glassfish Embedded Plugin
-
-Add Glassfish Embedded Plugin
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-glassfish-embedded
-```
-
-
-**Parameters**
-
-| Parameter     | Definition                                                      | Default value                |
-|---------------|-----------------------------------------------------------------|------------------------------|
-| `profile`     | This parameter defines the ID of the Maven profile to be added. | `glassfish`                  |
-| `port`        | This parameter defines the GlassFish port                       | `8080`                       |
-| `contextRoot` | Application Web Context Root                                    | `${project.build.finalName}` |
-
-### Add PayaraMicro Plugin
-
-Add PayaraMicro Plugin
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-payaramicro
-```
-
-### Add Domain Model
-
-The domain model is based using the definition of entities
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-domain-models
-```
-
-**Parameters**
-
-| Parameter       | Definition                                                                                        | Example                                 |
-|-----------------|---------------------------------------------------------------------------------------------------|-----------------------------------------|
-| `entities-file` | The name of the json file that contains the list of entities and their definitions to be created. | [entities.json](examples/entities.json) |
-
-**Example**
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-domain-models \
-    -Dentities-file=entities.json
-```
-
-### Add Forms (Primefaces) from Entities
-
-```shell
-mvn com.apuntesdejava:jakarta-coffee-builder-plugin:0.0.5:add-forms-from-entities
-```
-
-**Parameters**
-
-| Parameter       | Definition                                                                                         | Example                                 |
-|-----------------|----------------------------------------------------------------------------------------------------|-----------------------------------------|
-| `entities-file` | The name  of the json file that contains the list of entities and their definitions to be created. | [entities.json](examples/entities.json) |
-| `forms-file`    | The name of the json file that contains the list of forms and columns to Faces Pages               | [forms.json](examples/forms.json)       |
-
-
-**Example JSON File**
-```json
-{
-  "CategoryList": {
-    "entity": "Category",
-    "title": "Categories List",
-    "base": "/",
-    "template": {
-      "facelet": "/WEB-INF/templates/template1.xhtml",
-      "define": "body"
-    },
-    "fields": {
-      "id": {
-        "label": "Category Id"
-      },
-      "name": {
-        "label": "Category Name"
-      }
-    }
-  }
-}
-```
- 

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.apuntesdejava</groupId>
     <artifactId>jakarta-coffee-builder-plugin</artifactId>
-    <version>0.0.5-SNAPSHOT</version>
+    <version>0.0.6-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -32,8 +32,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.version>3.9.9</maven.version>
         <maven.compiler.release>21</maven.compiler.release>
-        <maven-plugin-tools.version>3.15.1</maven-plugin-tools.version>
-        <mockito.version>5.19.0</mockito.version>
+        <maven-plugin-tools.version>3.15.2</maven-plugin-tools.version>
+        <mockito.version>5.20.0</mockito.version>
         <org.slf4j-version>2.0.17</org.slf4j-version>
         <junit-jupiter.version>5.13.1</junit-jupiter.version>
     </properties>
@@ -88,12 +88,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
+            <version>3.20.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.20.0</version>
+            <version>2.21.0</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
@@ -108,12 +108,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.5</version>
+            <version>5.5.1</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.19.0</version>
+            <version>1.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -171,7 +171,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.14.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
@@ -179,7 +179,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.3</version>
+                    <version>3.5.4</version>
                     <configuration>
                         <argLine>
                             -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
@@ -189,7 +189,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -294,7 +294,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.11.3</version>
+                        <version>3.12.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,12 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.9.14</maven.version>
+        <maven.version>3.9.16</maven.version>
         <maven.compiler.release>21</maven.compiler.release>
         <maven-plugin-tools.version>3.15.2</maven-plugin-tools.version>
-        <mockito.version>5.21.0</mockito.version>
-        <org.slf4j-version>2.0.17</org.slf4j-version>
-        <junit-jupiter.version>6.0.3</junit-jupiter.version>
+        <mockito.version>5.23.0</mockito.version>
+        <org.slf4j-version>2.0.18</org.slf4j-version>
+        <junit-jupiter.version>6.1.1</junit-jupiter.version>
     </properties>
     <scm>
         <connection>scm:git:git://github.com/jakarta-coffee-builder/jakarta-coffee-builder-plugin.git</connection>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.21.0</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
-            <version>1.1.7</version>
+            <version>1.1.9</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.21.0</version>
+            <version>1.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.6</version>
         </dependency>
     </dependencies>
 
@@ -332,7 +332,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.9.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <!--<publishingServerId>central-portal-snapshots</publishingServerId>-->
@@ -351,7 +351,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.9.1</version>
+                        <version>3.10.1</version>
                         <configuration>
                             <postBuildHookScript>verify</postBuildHookScript>
                             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
         <maven.version>3.9.9</maven.version>
         <maven.compiler.release>21</maven.compiler.release>
         <maven-plugin-tools.version>3.15.2</maven-plugin-tools.version>
-        <mockito.version>5.20.0</mockito.version>
+        <mockito.version>5.21.0</mockito.version>
         <org.slf4j-version>2.0.17</org.slf4j-version>
-        <junit-jupiter.version>5.13.1</junit-jupiter.version>
+        <junit-jupiter.version>6.0.3</junit-jupiter.version>
     </properties>
     <scm>
         <connection>scm:git:git://github.com/jakarta-coffee-builder/jakarta-coffee-builder-plugin.git</connection>
@@ -106,11 +106,6 @@
             <version>1.1.7</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>5.5.1</version>
-        </dependency>
-        <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.10.1</version>
@@ -131,6 +126,17 @@
             <version>1.20.0</version>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
@@ -167,7 +173,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -253,8 +259,25 @@
                     </execution>
                 </executions>
             </plugin>
-
-
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -281,7 +304,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.1</version>
+                        <version>3.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.apuntesdejava</groupId>
     <artifactId>jakarta-coffee-builder-plugin</artifactId>
-    <version>0.0.6-SNAPSHOT</version>
+    <version>0.0.6</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.9.9</maven.version>
+        <maven.version>3.9.14</maven.version>
         <maven.compiler.release>21</maven.compiler.release>
         <maven-plugin-tools.version>3.15.2</maven-plugin-tools.version>
         <mockito.version>5.21.0</mockito.version>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.20.0</version>
+            <version>1.21.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -136,7 +136,8 @@
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
-        </dependency>        <dependency>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
@@ -165,7 +166,7 @@
     </dependencies>
 
     <build>
-        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+        <pluginManagement>
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
@@ -177,7 +178,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.1</version>
+                    <version>3.15.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
@@ -220,11 +221,6 @@
                     <goalPrefix>jakarta-coffee-builder</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
-<!--                <executions>
-                    <execution>
-                        <goals><goal>descriptor</goal></goals>
-                    </execution>
-                </executions>-->
                 <executions>
                     <execution>
                         <id>mojo-descriptor</id>

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/ArchitectureHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/ArchitectureHelper.java
@@ -66,11 +66,11 @@ public class ArchitectureHelper {
     }
 
     private static void addMapStructDependency(MavenProject mavenProject, Log log) throws IOException {
-        var version = PomUtil.findLatestDependencyVersion(ORG_MAPSTRUCT, MAPSTRUCT).orElseThrow();
+        var version = PomUtil.findLatestDependencyVersion(log, ORG_MAPSTRUCT, MAPSTRUCT).orElseThrow();
         PomUtil.setProperty(mavenProject, log, "org.mapstruct.version", version);
         PomUtil.addDependency(mavenProject, log, ORG_MAPSTRUCT, MAPSTRUCT, "${org.mapstruct.version}");
 
-        CoffeeBuilderUtil.getDependencyConfiguration(MAVEN_COMPILER_PLUGIN)
+        CoffeeBuilderUtil.getDependencyConfiguration(log, MAVEN_COMPILER_PLUGIN)
             .ifPresent(
                 mavenCompilerPlugin -> PomUtil.addPlugin(mavenProject, log,
                     ORG_APACHE_MAVEN_PLUGINS,
@@ -137,7 +137,7 @@ public class ArchitectureHelper {
             var packageDefinition = MavenProjectUtil.getModelPackage(mavenProject);
             log.debug("Model:" + modelName);
             var modelPath = PathsUtil.getJavaPath(mavenProject, packageDefinition, modelName);
-            var classDefinitionHelper = ClassDefinitionHelper.getInstance();
+            var classDefinitionHelper = ClassDefinitionHelper.getInstance(log);
             var fieldsJson = modelDefinition.getJsonObject(FIELDS);
             var fields = classDefinitionHelper.createFieldsDefinitions(fieldsJson,
                 (fieldName, field, annotations) -> {
@@ -233,7 +233,7 @@ public class ArchitectureHelper {
             var entityDefinition = entityDefinitionValue.asJsonObject();
 
             Collection<String> importsList = new ArrayList<>(
-                ClassDefinitionHelper.getInstance().importsFromFieldsClassesType(entityDefinition.getJsonObject(FIELDS))
+                ClassDefinitionHelper.getInstance(log).importsFromFieldsClassesType(entityDefinition.getJsonObject(FIELDS))
             );
 
             importsList.addAll(List.of(
@@ -291,7 +291,7 @@ public class ArchitectureHelper {
             var entityDefinition = entityDefinitionValue.asJsonObject();
 
             Collection<String> importsList = new ArrayList<>(
-                ClassDefinitionHelper.getInstance().importsFromFieldsClassesType(entityDefinition.getJsonObject(FIELDS))
+                ClassDefinitionHelper.getInstance(log).importsFromFieldsClassesType(entityDefinition.getJsonObject(FIELDS))
             );
 
             importsList.add(

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/ClassDefinitionHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/ClassDefinitionHelper.java
@@ -22,6 +22,7 @@ import com.apuntesdejava.jakartacoffeebuilder.util.StringsUtil;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import org.apache.commons.lang3.function.TriFunction;
+import org.apache.maven.plugin.logging.Log;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -48,9 +49,9 @@ public class ClassDefinitionHelper {
 
     private final JsonObject classesDefinitions;
 
-    private ClassDefinitionHelper() {
+    private ClassDefinitionHelper(Log log) {
         try {
-            this.classesDefinitions = CoffeeBuilderUtil.getClassesDefinitions().orElseThrow();
+            this.classesDefinitions = CoffeeBuilderUtil.getClassesDefinitions(log).orElseThrow();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -61,14 +62,14 @@ public class ClassDefinitionHelper {
      *
      * @return The single instance of this class.
      */
-    public static ClassDefinitionHelper getInstance() {
-        return ClassDefinitionHelperHolder.INSTANCE;
+    public static synchronized ClassDefinitionHelper getInstance(Log log) {
+         if (INSTANCE == null){
+             INSTANCE = new ClassDefinitionHelper(log);
+         }
+         return INSTANCE;
     }
 
-    private static class ClassDefinitionHelperHolder {
-
-        private static final ClassDefinitionHelper INSTANCE = new ClassDefinitionHelper();
-    }
+    private static  ClassDefinitionHelper INSTANCE ;
 
     /**
      * Creates a list of field definitions from a JSON object representing the fields of a class.

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/GlassFishHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/GlassFishHelper.java
@@ -98,11 +98,11 @@ public class GlassFishHelper {
      */
     public Optional<Path> download(MavenProject mavenProject, Log log, String jakartaEeVersion) throws IOException {
         return CoffeeBuilderUtil
-            .getServerDefinition("glassfish")
+            .getServerDefinition(log, "glassfish")
             .map(def -> def.getString(jakartaEeVersion))
             .map(glassfishVersion -> {
                 try {
-                    var artifact = PomUtil.getArtifactInfo("org.glassfish.main.extras", "glassfish-embedded-all",
+                    var artifact = PomUtil.getArtifactInfo(log, "org.glassfish.main.extras", "glassfish-embedded-all",
                         glassfishVersion);
                     String uri = StringUtils.replaceChars(artifact.getString("g"), ".", "/");
                     String artifactId = artifact.getString("a");

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
@@ -83,10 +83,10 @@ public final class JakartaEeHelper {
     private JakartaEeHelper() {
     }
 
-    private JsonObject getSpecifications() {
+    private JsonObject getSpecifications(Log log) {
         if (this.specifications == null) {
             try {
-                CoffeeBuilderUtil.getSpecificationsDefinitions().ifPresent(specs -> this.specifications = specs);
+                CoffeeBuilderUtil.getSpecificationsDefinitions(log).ifPresent(specs -> this.specifications = specs);
             } catch (IOException e) {
                 throw new RuntimeException("Error loading Jakarta EE specifications from remote resource", e);
             }
@@ -105,7 +105,7 @@ public final class JakartaEeHelper {
     public void addJakartaCdiDependency(MavenProject mavenProject,
                                         Log log,
                                         String jakartaEeVersion) throws MojoExecutionException {
-        var jakartaCdiVersion = getSpecifications().getJsonObject(jakartaEeVersion).getString(JAKARTA_ENTERPRISE_CDI_API);
+        var jakartaCdiVersion = getSpecifications(log).getJsonObject(jakartaEeVersion).getString(JAKARTA_ENTERPRISE_CDI_API);
         PomUtil.addDependency(mavenProject, log, JAKARTA_ENTERPRISE, JAKARTA_ENTERPRISE_CDI_API, jakartaCdiVersion,
             PROVIDED_SCOPE);
     }
@@ -120,7 +120,7 @@ public final class JakartaEeHelper {
     public void addJakartaFacesDependency(MavenProject mavenProject,
                                           Log log,
                                           String jakartaEeVersion) {
-        var jakartaFacesVersion = getSpecifications().getJsonObject(jakartaEeVersion).getString(JAKARTA_FACES_API);
+        var jakartaFacesVersion = getSpecifications(log).getJsonObject(jakartaEeVersion).getString(JAKARTA_FACES_API);
         PomUtil.addDependency(mavenProject, log, JAKARTA_FACES, JAKARTA_FACES_API, jakartaFacesVersion, PROVIDED_SCOPE);
     }
 
@@ -153,7 +153,7 @@ public final class JakartaEeHelper {
     public void addJakartaTransactionDependency(MavenProject mavenProject,
                                                 Log log,
                                                 String jakartaEeVersion) {
-        Optional.ofNullable(getSpecifications().getJsonObject(jakartaEeVersion)
+        Optional.ofNullable(getSpecifications(log).getJsonObject(jakartaEeVersion)
                 .getString(JAKARTA_TRANSACTION_API))
             .ifPresentOrElse(jakartaPersistenceVersion -> PomUtil.addDependency(mavenProject,
                     log,
@@ -224,7 +224,7 @@ public final class JakartaEeHelper {
     public void addJakartaPersistenceDependency(MavenProject mavenProject,
                                                 Log log,
                                                 String jakartaEeVersion) {
-        var jakartaPersistenceVersion = getSpecifications().getJsonObject(jakartaEeVersion)
+        var jakartaPersistenceVersion = getSpecifications(log).getJsonObject(jakartaEeVersion)
             .getString(JAKARTA_PERSISTENCE_API);
         PomUtil.addDependency(mavenProject, log, JAKARTA_PERSISTENCE, JAKARTA_PERSISTENCE_API,
             jakartaPersistenceVersion, PROVIDED_SCOPE);
@@ -294,7 +294,7 @@ public final class JakartaEeHelper {
     public void addJakartaDataDependency(MavenProject mavenProject,
                                          Log log,
                                          String jakartaEeVersion) throws MojoExecutionException {
-        var jakartaPersistenceVersion = getSpecifications().getJsonObject(jakartaEeVersion).getString(JAKARTA_DATA_API);
+        var jakartaPersistenceVersion = getSpecifications(log).getJsonObject(jakartaEeVersion).getString(JAKARTA_DATA_API);
         PomUtil.addDependency(mavenProject,
             log,
             JAKARTA_DATA,
@@ -316,7 +316,7 @@ public final class JakartaEeHelper {
             artifact -> {
                 var version = artifact.getVersion();
                 log.debug("Jakarta CDI dependency found: " + version);
-                getSpecifications().entrySet().stream()
+                getSpecifications(log).entrySet().stream()
                     .filter(entry -> {
                         JsonObject specObject = entry.getValue().asJsonObject();
                         return specObject.containsKey(JAKARTA_ENTERPRISE_CDI_API)
@@ -398,7 +398,7 @@ public final class JakartaEeHelper {
      * @throws IOException If an I/O error occurs while fetching dependency configurations.
      */
     public void addJacksonDependency(MavenProject mavenProject, Log log) throws IOException {
-        CoffeeBuilderUtil.getDependencyConfiguration("jackson-core")
+        CoffeeBuilderUtil.getDependencyConfiguration(log, "jackson-core" )
             .ifPresent(hibernate -> {
                 PomUtil .setProperty(mavenProject, log, "jackson-core.version",
                                 hibernate.getString("version"));
@@ -419,7 +419,7 @@ public final class JakartaEeHelper {
      */
     public void addMicroprofileOpenApiApiDependency(MavenProject mavenProject,
                                                     Log log) throws IOException {
-        CoffeeBuilderUtil.getDependencyConfiguration("microprofile-openapi-api")
+        CoffeeBuilderUtil.getDependencyConfiguration(log, "microprofile-openapi-api" )
             .ifPresent(
                 openApi -> PomUtil
                     .setProperty(mavenProject, log, "microprofile-openapi-api.version",
@@ -441,7 +441,7 @@ public final class JakartaEeHelper {
     public void addJakartaValidationApiDependency(MavenProject mavenProject,
                                                   Log log,
                                                   String jakartaEeVersion) throws IOException, MojoExecutionException {
-        var openApi = CoffeeBuilderUtil.getDependencyConfiguration("jakarta.validation-api-" + jakartaEeVersion)
+        var openApi = CoffeeBuilderUtil.getDependencyConfiguration(log, "jakarta.validation-api-" + jakartaEeVersion )
             .orElseThrow(() -> new MojoExecutionException("Dependency not found"));
         PomUtil.setProperty(mavenProject, log, "jakarta.validation-api.version",
             openApi.getString("version"));
@@ -478,7 +478,7 @@ public final class JakartaEeHelper {
                 )*/
             ).build();
         PomUtil
-            .findLatestPluginVersion("org.codehaus.mojo", "build-helper-maven-plugin")
+            .findLatestPluginVersion(log, "org.codehaus.mojo", "build-helper-maven-plugin")
             .ifPresent(
                 version -> PomUtil.addPlugin(mavenProject.getOriginalModel().getBuild(), log, "org.codehaus.mojo",
                     "build-helper-maven-plugin", version, null, executions));

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
@@ -254,24 +254,33 @@ public final class JakartaEeHelper {
      * @param log          The Maven logger for output.
      * @param declare      The strategy for declaring the data source (e.g., "web.xml", "payara").
      * @param json         A {@link JsonObject} containing the data source configuration parameters.
+     * @param profile   The profile name to which the data source configuration should be applied (if applicable).
      */
     public void addDataSource(MavenProject mavenProject,
                               Log log,
                               String declare,
-                              JsonObject json) {
+                              JsonObject json,
+                              String profile) {
         log.debug("Datasource:%s".formatted(json));
         DataSourceCreatorFactory
-            .getDataSourceCreator(mavenProject, log, declare)
+            .getDataSourceCreator(mavenProject, log, declare, profile)
             .ifPresent(dataSourceCreator -> {
                 try {
                     dataSourceCreator
                         .dataSourceParameters(json)
                         .build();
-                } catch (IOException e) {
+                } catch (IOException | MojoExecutionException e) {
                     log.error("Error creating datasource", e);
                     throw new RuntimeException(e);
                 }
             });
+    }
+
+    public void addDataSource(MavenProject mavenProject,
+                              Log log,
+                              String declare,
+                              JsonObject json ) {
+        addDataSource(mavenProject, log, declare, json, null);
     }
 
     /**

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
@@ -390,13 +390,15 @@ public final class JakartaEeHelper {
      */
     public void addJacksonDependency(MavenProject mavenProject, Log log) throws IOException {
         CoffeeBuilderUtil.getDependencyConfiguration("jackson-core")
-            .ifPresent(hibernate -> PomUtil
-                .setProperty(mavenProject, log, "jackson-core.version",
-                    hibernate.getString("version")));
-        PomUtil.addDependency(mavenProject, log, "com.fasterxml.jackson.core", "jackson-core",
-            "${jackson-core.version}");
-        PomUtil.addDependency(mavenProject, log, "com.fasterxml.jackson.core", "jackson-annotations",
-            "${jackson-core.version}");
+            .ifPresent(hibernate -> {
+                PomUtil .setProperty(mavenProject, log, "jackson-core.version",
+                                hibernate.getString("version"));
+                var groupId= hibernate.getString("groupId");
+            PomUtil.addDependency(mavenProject, log, groupId, "jackson-core",
+                "${jackson-core.version}");
+            PomUtil.addDependency(mavenProject, log, groupId, "jackson-annotations",
+                "${jackson-core.version}");
+        });
     }
 
     /**

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaEeHelper.java
@@ -81,11 +81,17 @@ public final class JakartaEeHelper {
     }
 
     private JakartaEeHelper() {
-        try {
-            CoffeeBuilderUtil.getSpecificationsDefinitions().ifPresent(specs -> this.specifications = specs);
-        } catch (IOException e) {
-            throw new RuntimeException(e.getMessage(), e);
+    }
+
+    private JsonObject getSpecifications() {
+        if (this.specifications == null) {
+            try {
+                CoffeeBuilderUtil.getSpecificationsDefinitions().ifPresent(specs -> this.specifications = specs);
+            } catch (IOException e) {
+                throw new RuntimeException("Error loading Jakarta EE specifications from remote resource", e);
+            }
         }
+        return this.specifications;
     }
 
     /**
@@ -99,7 +105,7 @@ public final class JakartaEeHelper {
     public void addJakartaCdiDependency(MavenProject mavenProject,
                                         Log log,
                                         String jakartaEeVersion) throws MojoExecutionException {
-        var jakartaCdiVersion = specifications.getJsonObject(jakartaEeVersion).getString(JAKARTA_ENTERPRISE_CDI_API);
+        var jakartaCdiVersion = getSpecifications().getJsonObject(jakartaEeVersion).getString(JAKARTA_ENTERPRISE_CDI_API);
         PomUtil.addDependency(mavenProject, log, JAKARTA_ENTERPRISE, JAKARTA_ENTERPRISE_CDI_API, jakartaCdiVersion,
             PROVIDED_SCOPE);
     }
@@ -114,7 +120,7 @@ public final class JakartaEeHelper {
     public void addJakartaFacesDependency(MavenProject mavenProject,
                                           Log log,
                                           String jakartaEeVersion) {
-        var jakartaFacesVersion = specifications.getJsonObject(jakartaEeVersion).getString(JAKARTA_FACES_API);
+        var jakartaFacesVersion = getSpecifications().getJsonObject(jakartaEeVersion).getString(JAKARTA_FACES_API);
         PomUtil.addDependency(mavenProject, log, JAKARTA_FACES, JAKARTA_FACES_API, jakartaFacesVersion, PROVIDED_SCOPE);
     }
 
@@ -147,7 +153,7 @@ public final class JakartaEeHelper {
     public void addJakartaTransactionDependency(MavenProject mavenProject,
                                                 Log log,
                                                 String jakartaEeVersion) {
-        Optional.ofNullable(specifications.getJsonObject(jakartaEeVersion)
+        Optional.ofNullable(getSpecifications().getJsonObject(jakartaEeVersion)
                 .getString(JAKARTA_TRANSACTION_API))
             .ifPresentOrElse(jakartaPersistenceVersion -> PomUtil.addDependency(mavenProject,
                     log,
@@ -218,7 +224,7 @@ public final class JakartaEeHelper {
     public void addJakartaPersistenceDependency(MavenProject mavenProject,
                                                 Log log,
                                                 String jakartaEeVersion) {
-        var jakartaPersistenceVersion = specifications.getJsonObject(jakartaEeVersion)
+        var jakartaPersistenceVersion = getSpecifications().getJsonObject(jakartaEeVersion)
             .getString(JAKARTA_PERSISTENCE_API);
         PomUtil.addDependency(mavenProject, log, JAKARTA_PERSISTENCE, JAKARTA_PERSISTENCE_API,
             jakartaPersistenceVersion, PROVIDED_SCOPE);
@@ -279,7 +285,7 @@ public final class JakartaEeHelper {
     public void addJakartaDataDependency(MavenProject mavenProject,
                                          Log log,
                                          String jakartaEeVersion) throws MojoExecutionException {
-        var jakartaPersistenceVersion = specifications.getJsonObject(jakartaEeVersion).getString(JAKARTA_DATA_API);
+        var jakartaPersistenceVersion = getSpecifications().getJsonObject(jakartaEeVersion).getString(JAKARTA_DATA_API);
         PomUtil.addDependency(mavenProject,
             log,
             JAKARTA_DATA,
@@ -301,7 +307,7 @@ public final class JakartaEeHelper {
             artifact -> {
                 var version = artifact.getVersion();
                 log.debug("Jakarta CDI dependency found: " + version);
-                specifications.entrySet().stream()
+                getSpecifications().entrySet().stream()
                     .filter(entry -> {
                         JsonObject specObject = entry.getValue().asJsonObject();
                         return specObject.containsKey(JAKARTA_ENTERPRISE_CDI_API)

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaPersistenceHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/JakartaPersistenceHelper.java
@@ -15,13 +15,7 @@
  */
 package com.apuntesdejava.jakartacoffeebuilder.helper;
 
-import com.apuntesdejava.jakartacoffeebuilder.util.CoffeeBuilderUtil;
-import com.apuntesdejava.jakartacoffeebuilder.util.JsonUtil;
-import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
-import com.apuntesdejava.jakartacoffeebuilder.util.PathsUtil;
-import com.apuntesdejava.jakartacoffeebuilder.util.StringsUtil;
-import com.apuntesdejava.jakartacoffeebuilder.util.TemplateUtil;
-import com.apuntesdejava.jakartacoffeebuilder.util.XmlUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.*;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
@@ -32,28 +26,11 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.CLASS_NAME;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.FIELDS;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.FULL_NAME;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.GENERATED_VALUE;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.GENERATION_TYPES;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.IMPORTS_LIST;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.PACKAGE_NAME;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.SEARCH_ANNOTATIONS_FIELD_KEYS;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.TABLE_NAME;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.TYPE;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.*;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 /**
@@ -70,7 +47,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
  * </ul>
  *
  * <p>
- * Note: This class is not intended to be instantiated directly. Use {@link #getInstance()} to obtain the singleton
+ * Note: This class is not intended to be instantiated directly. Use {@link #getInstance(Log)} to obtain the singleton
  * instance.</p>
  *
  * @author Diego Silva diego.silva at apuntesdejava.com
@@ -81,12 +58,13 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
  */
 public class JakartaPersistenceHelper {
 
+    private static JakartaPersistenceHelper INSTANCE;
     private final JsonObject classesDefinitions;
     private final String suffix;
 
-    private JakartaPersistenceHelper() {
+    private JakartaPersistenceHelper(Log log) {
         try {
-            this.classesDefinitions = CoffeeBuilderUtil.getClassesDefinitions().orElseThrow();
+            this.classesDefinitions = CoffeeBuilderUtil.getClassesDefinitions(log).orElseThrow();
             this.suffix = "Entity";
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -99,8 +77,11 @@ public class JakartaPersistenceHelper {
      *
      * @return the singleton instance of `JakartaPersistenceHelper`
      */
-    public static JakartaPersistenceHelper getInstance() {
-        return JakartaPersistenceUtilHolder.INSTANCE;
+    public static synchronized JakartaPersistenceHelper getInstance(Log log) {
+        if (INSTANCE == null) {
+            INSTANCE = new JakartaPersistenceHelper(log);
+        }
+        return INSTANCE;
     }
 
     /**
@@ -122,9 +103,9 @@ public class JakartaPersistenceHelper {
         var persistenceDoc = xmlUtil.getDocument(log, persistenceXmlPath).orElseThrow();
         var jsonContent = JsonUtil.readJsonValue(jsonPath).asJsonObject();
         var entitiesName = jsonContent.keySet()
-            .stream()
-            .map(className -> className + suffix)
-            .collect(Collectors.toSet());
+                .stream()
+                .map(className -> className + suffix)
+                .collect(Collectors.toSet());
         jsonContent.forEach((key, value) -> addEntity(mavenProject, log, key, value.asJsonObject(), entitiesName));
 
         xmlUtil.saveDocument(persistenceDoc, log, persistenceXmlPath);
@@ -145,10 +126,10 @@ public class JakartaPersistenceHelper {
         log.debug("Adding repository for entity: " + entityName);
         var repositoryBuilder = RepositoryBuilder.getInstance();
         repositoryBuilder
-            .buildRepository(mavenProject, log, entityName + suffix, entity,
-                ClassDefinitionHelper.getInstance()
-                    .importsFromFieldsClassesType(entity
-                        .getJsonObject(FIELDS)));
+                .buildRepository(mavenProject, log, entityName + suffix, entity,
+                        ClassDefinitionHelper.getInstance(log)
+                                .importsFromFieldsClassesType(entity
+                                        .getJsonObject(FIELDS)));
 
     }
 
@@ -165,27 +146,27 @@ public class JakartaPersistenceHelper {
 
             var fieldsJson = entity.getJsonObject(FIELDS);
             Collection<String> importsList = new LinkedHashSet<>();
-            var classDefinitionHelper = ClassDefinitionHelper.getInstance();
+            var classDefinitionHelper = ClassDefinitionHelper.getInstance(log);
             var fields = classDefinitionHelper
-                .createFieldsDefinitions(fieldsJson,
-                    (fieldName, field, annotations) -> getFieldType(
-                        mavenProject,
-                        log,
-                        entityName,
-                        entitiesName,
-                        fieldName,
-                        field,
-                        annotations,
-                        importsList));
+                    .createFieldsDefinitions(fieldsJson,
+                            (fieldName, field, annotations) -> getFieldType(
+                                    mavenProject,
+                                    log,
+                                    entityName,
+                                    entitiesName,
+                                    fieldName,
+                                    field,
+                                    annotations,
+                                    importsList));
             importsList.addAll(createImportsCollectionFromSearchAnnotation(fieldsJson));
             importsList.addAll(createImportsCollectionFromGeneratedValue(fieldsJson));
             importsList.addAll(classDefinitionHelper.importsFromFieldsClassesType(fieldsJson));
 
             Map<String, Object> fieldsMap = new LinkedHashMap<>(
-                Map.of(PACKAGE_NAME, packageDefinition,
-                    CLASS_NAME, entityName,
-                    IMPORTS_LIST, importsList,
-                    FIELDS, fields));
+                    Map.of(PACKAGE_NAME, packageDefinition,
+                            CLASS_NAME, entityName,
+                            IMPORTS_LIST, importsList,
+                            FIELDS, fields));
             if (StringUtils.isBlank(tableName)) {
                 fieldsMap.put("tableName", Strings.CS.removeEnd(entityName, suffix));
             } else {
@@ -193,7 +174,7 @@ public class JakartaPersistenceHelper {
             }
 
             TemplateUtil.getInstance()
-                .createEntityFile(log, fieldsMap, entityPath);
+                    .createEntityFile(log, fieldsMap, entityPath);
         } catch (IOException ex) {
             log.error("Error adding entity: " + entity.getString(NAME), ex);
         }
@@ -201,13 +182,13 @@ public class JakartaPersistenceHelper {
 
     private Collection<String> createImportsCollectionFromGeneratedValue(JsonObject fieldsJson) {
         return fieldsJson.values().stream()
-            .map(JsonValue::asJsonObject)
-            .filter(field -> field.containsKey(GENERATED_VALUE)
-                && StringsUtil
-                .findIgnoreCaseOptional(GENERATION_TYPES, field.getString(GENERATED_VALUE)).isPresent())
-            .findFirst()
-            .map(generatedValue -> Set.of("jakarta.persistence.GeneratedValue", "jakarta.persistence.GenerationType"))
-            .orElse(Collections.emptySet());
+                .map(JsonValue::asJsonObject)
+                .filter(field -> field.containsKey(GENERATED_VALUE)
+                        && StringsUtil
+                        .findIgnoreCaseOptional(GENERATION_TYPES, field.getString(GENERATED_VALUE)).isPresent())
+                .findFirst()
+                .map(generatedValue -> Set.of("jakarta.persistence.GeneratedValue", "jakarta.persistence.GenerationType"))
+                .orElse(Collections.emptySet());
     }
 
     private String getFieldType(MavenProject mavenProject,
@@ -224,7 +205,7 @@ public class JakartaPersistenceHelper {
         }
         if (Strings.CS.equals(type, "enum")) {
             return evaluateFieldEnumType(mavenProject, log, entityName, fieldName, field, importsList,
-                annotations);
+                    annotations);
         }
         if (entitiesName.contains(type + suffix)) {
             return type + suffix;
@@ -239,13 +220,13 @@ public class JakartaPersistenceHelper {
                                          JsonObject field,
                                          Collection<String> importsList, List<Map<String, Object>> annotations) {
         var enumValues = field
-            .getJsonArray("values")
-            .stream()
-            .map(jsonValue -> (JsonString) jsonValue)
-            .map(JsonString::getString)
-            .toList();
+                .getJsonArray("values")
+                .stream()
+                .map(jsonValue -> (JsonString) jsonValue)
+                .map(JsonString::getString)
+                .toList();
         var fullName = createEnum(mavenProject, log, entityName + StringUtils.capitalize(fieldName),
-            enumValues);
+                enumValues);
         importsList.add(fullName);
         importsList.add("jakarta.persistence.Enumerated");
         /*   importsList.add("jakarta.persistence.EnumType");
@@ -285,9 +266,9 @@ public class JakartaPersistenceHelper {
             var enumPath = PathsUtil.getJavaPath(mavenProject, packageDefinition, enumName);
             log.debug("Creating enum: " + enumName + " at " + enumPath);
             Map<String, Object> model = Map.of(
-                PACKAGE_NAME, packageDefinition,
-                CLASS_NAME, enumName,
-                "values", values
+                    PACKAGE_NAME, packageDefinition,
+                    CLASS_NAME, enumName,
+                    "values", values
             );
             TemplateUtil.getInstance().createEnumFile(log, model, enumPath);
             return packageDefinition + "." + enumName;
@@ -300,17 +281,14 @@ public class JakartaPersistenceHelper {
 
     private Collection<String> createImportsCollectionFromSearchAnnotation(JsonObject fieldsJson) {
         return fieldsJson.values().stream()
-            .map(JsonValue::asJsonObject)
-            .map(JsonObject::keySet)
-            .flatMap(Set::stream)
-            .map(key -> StringsUtil.findIgnoreCase(SEARCH_ANNOTATIONS_FIELD_KEYS, key))
-            .filter(Objects::nonNull)
-            .map(key -> "jakarta.persistence." + key)
-            .collect(Collectors.toSet());
+                .map(JsonValue::asJsonObject)
+                .map(JsonObject::keySet)
+                .flatMap(Set::stream)
+                .map(key -> StringsUtil.findIgnoreCase(SEARCH_ANNOTATIONS_FIELD_KEYS, key))
+                .filter(Objects::nonNull)
+                .map(key -> "jakarta.persistence." + key)
+                .collect(Collectors.toSet());
     }
 
-    private static class JakartaPersistenceUtilHolder {
 
-        private static final JakartaPersistenceHelper INSTANCE = new JakartaPersistenceHelper();
-    }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/OpenApiGeneratorHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/OpenApiGeneratorHelper.java
@@ -27,6 +27,7 @@ import org.apache.maven.project.MavenProject;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,6 +65,12 @@ public class OpenApiGeneratorHelper {
      * This file lists files and directories that should not be overwritten during code generation.
      */
     public static final String OPENAPI_GENERATOR_IGNORE_FILENAME = ".openapi-generator-ignore";
+    private static final String OPENAPI_TEMPLATES_RESOURCE_DIR = "openapi-templates";
+    private static final String OPENAPI_TEMPLATES_PROJECT_DIR = "src/main/openapi-templates";
+    private static final List<String> OPENAPI_TEMPLATE_FILES = List.of(
+        "pojo.mustache",
+        "enumOuterClass.mustache"
+    );
 
     /**
      * Retrieves the singleton instance of the {@code OpenApiGeneratorHelper}.
@@ -110,19 +117,23 @@ public class OpenApiGeneratorHelper {
             throw new FileNotFoundException("File not found:" + openApiFile);
         }
         Path openApiPath = copyToProjectPath(mavenProject.getBasedir(), openApiFile);
+        Path openApiTemplatesPath = copyOpenApiTemplatesToProject(mavenProject.getBasedir());
         var apiResourcesPackage = MavenProjectUtil.getApiResourcesPackage(mavenProject);
         createIgnoreFilePath(mavenProject.getBasedir());
 
         CoffeeBuilderUtil
-            .getOpenApiGeneratorConfiguration()
+            .getOpenApiGeneratorConfiguration(log)
             .map(config -> {
                 var configOptionsBuilder = Json.createObjectBuilder(config.getJsonObject("configOptions"))
                     .add("modelPackage", apiResourcesPackage + ".model")
-                    .add("apiPackage", apiResourcesPackage);
+                    .add("apiPackage", apiResourcesPackage)
+                    .add("openApiNullable", false)
+                    .add("generateJsonCreator", false);
                 return Json.createObjectBuilder()
                     .add("generatorName", config.getString("generatorName"))
                     .add("inputSpec", openApiPath.getFileName().toString())
                     .add("ignoreFileOverride", "${project.basedir}/" + OPENAPI_GENERATOR_IGNORE_FILENAME)
+                    .add("templateDirectory", "${project.basedir}/" + openApiTemplatesPath.toString().replace("\\", "/"))
                     .add("configOptions", configOptionsBuilder)
                     .build();
             }).ifPresent(configuration -> {
@@ -138,12 +149,16 @@ public class OpenApiGeneratorHelper {
                                     )
                             ).add(CONFIGURATION, configuration))
                         .build();
-                    PomUtil.findLatestPluginVersion(Constants.ORG_OPENAPITOOLS, Constants.OPENAPI_GENERATOR_MAVEN_PLUGIN)
-                        .ifPresent(version
-                            -> PomUtil.addPlugin(mavenProject.getOriginalModel().getBuild(), log,
-                            Constants.ORG_OPENAPITOOLS,
-                            Constants.OPENAPI_GENERATOR_MAVEN_PLUGIN, version, null, executions)
-                        );
+                    CoffeeBuilderUtil.getDependencyConfiguration(log,Constants.OPENAPI_GENERATOR_MAVEN_PLUGIN)
+                        .ifPresent(dependency -> {
+                            PomUtil.addPlugin(mavenProject.getOriginalModel().getBuild(), log,
+                                    Constants.ORG_OPENAPITOOLS,
+                                    Constants.OPENAPI_GENERATOR_MAVEN_PLUGIN,
+                                    dependency.getString("version"),
+                                    null,
+                                    executions);
+                        });
+
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -155,6 +170,23 @@ public class OpenApiGeneratorHelper {
         Path path = Paths.get(basedir.getAbsolutePath(), openApiFile.getName());
         Files.copy(openApiFile.toPath(), path, StandardCopyOption.REPLACE_EXISTING);
         return path;
+    }
+
+    private Path copyOpenApiTemplatesToProject(File basedir) throws IOException {
+        Path templateDir = Paths.get(basedir.getAbsolutePath(), OPENAPI_TEMPLATES_PROJECT_DIR);
+        Files.createDirectories(templateDir);
+        for (String templateFile : OPENAPI_TEMPLATE_FILES) {
+            String resourcePath = OPENAPI_TEMPLATES_RESOURCE_DIR + "/" + templateFile;
+            try (InputStream inputStream = OpenApiGeneratorHelper.class
+                .getClassLoader()
+                .getResourceAsStream(resourcePath)) {
+                if (inputStream == null) {
+                    throw new FileNotFoundException("Resource not found:" + resourcePath);
+                }
+                Files.copy(inputStream, templateDir.resolve(templateFile), StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+        return Paths.get(OPENAPI_TEMPLATES_PROJECT_DIR);
     }
 
     private static class OpenApiGeneratorHelperHolder {

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
@@ -78,7 +78,7 @@ public class PayaraMicroHelper {
         if (!definition.containsKey(jakartaEeVersion))
             throw new MojoExecutionException("Jakarta EE version " + jakartaEeVersion + " doesn't exist");
         var configuration = Json.createObjectBuilder()
-            .add("payaraVersion", definition.getString(jakartaEeVersion))
+            .add("payaraMicroVersion", definition.getString(jakartaEeVersion))
             .add("deployWar", "false")
             .add("commandLineOptions",
                 Json.createObjectBuilder()
@@ -98,13 +98,21 @@ public class PayaraMicroHelper {
             )
             .build();
         var build = MavenProjectUtil.getBuild(mavenProject, profileId);
-        var plugin = PomUtil.addPlugin(build, log, "fish.payara.maven.plugins",
-            "payara-micro-maven-plugin", "2.4",
-            configuration);
-        log.debug("plugin: %s".formatted(plugin));
 
+        CoffeeBuilderUtil.getDependencyConfiguration("payara-micro-maven-plugin")
+                .ifPresent(pluginDef->{
+                    PomUtil.setProperty(mavenProject, log, "payara-micro-maven-plugin.version", pluginDef.getString("version"));
+                    PomUtil.addPlugin(build, log,
+                            pluginDef.getString("groupId"),
+                            pluginDef.getString("artifactId"),
+                            "${payara-micro-maven-plugin.version}",
+                            configuration
+                    );
+                });
 
     }
+
+
 
     private static class PayaraMicroHelperHolder {
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PayaraMicroHelper.java
@@ -71,8 +71,9 @@ public class PayaraMicroHelper {
      */
     public void addPlugin(MavenProject mavenProject,
                           Log log,
-                          String profileId, String jakartaEeVersion) throws IOException, MojoExecutionException {
-        Optional<JsonObject> definitionOpt = CoffeeBuilderUtil.getServerDefinition("payara");
+                          String profileId,
+                          String jakartaEeVersion) throws IOException, MojoExecutionException {
+        Optional<JsonObject> definitionOpt = CoffeeBuilderUtil.getServerDefinition(log, "payara");
         if (definitionOpt.isEmpty()) return;
         var definition = definitionOpt.get();
         if (!definition.containsKey(jakartaEeVersion))
@@ -99,7 +100,7 @@ public class PayaraMicroHelper {
             .build();
         var build = MavenProjectUtil.getBuild(mavenProject, profileId);
 
-        CoffeeBuilderUtil.getDependencyConfiguration("payara-micro-maven-plugin")
+        CoffeeBuilderUtil.getDependencyConfiguration(log, "payara-micro-maven-plugin")
                 .ifPresent(pluginDef->{
                     PomUtil.setProperty(mavenProject, log, "payara-micro-maven-plugin.version", pluginDef.getString("version"));
                     PomUtil.addPlugin(build, log,

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PersistenceXmlHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PersistenceXmlHelper.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.PROPERTIES;
 
 /**
  * Helper class for managing `persistence.xml` files. Provides methods to create and save `persistence.xml` documents.
@@ -91,7 +92,7 @@ public class PersistenceXmlHelper {
                 var persistenceUnitElem = xmlUtil.addElement(persistenceElem,
                     "persistence-unit",
                     Map.of(NAME, persistenceUnitName));
-                var propertiesElement = xmlUtil.addElement(persistenceUnitElem, "properties");
+                var propertiesElement = xmlUtil.addElement(persistenceUnitElem, PROPERTIES);
                 xmlUtil.addElement(propertiesElement, "property", Map.of(
                     "name", "jakarta.persistence.schema-generation.database.action",
                     "value", "drop-and-create"

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PersistenceXmlHelper.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/PersistenceXmlHelper.java
@@ -77,7 +77,7 @@ public class PersistenceXmlHelper {
             try {
                 var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(mavenProject, log)
                     .orElseThrow();
-                JsonObject schemaDescription = CoffeeBuilderUtil.getSchema(jakartaEeVersion,
+                JsonObject schemaDescription = CoffeeBuilderUtil.getSchema(log,jakartaEeVersion,
                         "persistence")
                     .orElseThrow();
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
@@ -1,0 +1,20 @@
+package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
+
+import java.io.IOException;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+
+public class DataSourceAsAdminCreator extends DataSourceCreator {
+
+  public DataSourceAsAdminCreator(MavenProject mavenProject, Log log) {
+    super(mavenProject, log);
+  }
+
+  @Override
+  public void build() throws IOException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'build'");
+  }
+
+}

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
@@ -1,20 +1,48 @@
 package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
 
-import java.io.IOException;
-
+import org.apache.commons.lang3.Strings;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Set;
+
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.CLASS_NAME;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
+
 public class DataSourceAsAdminCreator extends DataSourceCreator {
 
-  public DataSourceAsAdminCreator(MavenProject mavenProject, Log log) {
-    super(mavenProject, log);
-  }
+    public DataSourceAsAdminCreator(MavenProject mavenProject, Log log) {
+        super(mavenProject, log);
+    }
 
-  @Override
-  public void build() throws IOException {
-    // TODO Auto-generated method stub
-    throw new UnsupportedOperationException("Unimplemented method 'build'");
-  }
+    @Override
+    public void build() throws IOException {
+        var currentPath = mavenProject.getFile().toPath().getParent();
+        var postBootPath = currentPath.resolve("post-boot-commands.asadmin");
+        log.debug("Creating %s file".formatted(postBootPath));
+        var properties = getDataSourceParameters();
+        var commands = new StringBuilder();
+        commands.append("create-jdbc-connection-pool  ");
+        commands.append("--restype javax.sql.DataSource ");
+        commands.append("--datasourceclassname %s ".formatted(properties.get(CLASS_NAME)));
+        commands.append("--property \"");
+        properties.entrySet()
+            .stream()
+            .filter(entry -> !Set.of(CLASS_NAME, NAME).contains(entry.getKey()))
+            .forEach((entry) -> commands.append(entry.getKey())
+                .append("=")
+                .append(replaceColons((String) entry.getValue()))
+                .append(":"));
+        commands.deleteCharAt(commands.length() - 1);
+        commands.append("\" ");
 
+        Files.writeString(postBootPath, commands.toString());
+
+    }
+
+    private static String replaceColons(String value) {
+        return Strings.CS.replace(value, ":", "\\\\:");
+    }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceAsAdminCreator.java
@@ -1,11 +1,19 @@
 package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.maven.model.ConfigurationContainer;
+import org.apache.maven.model.Profile;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.CLASS_NAME;
@@ -13,36 +21,94 @@ import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
 
 public class DataSourceAsAdminCreator extends DataSourceCreator {
 
-    public DataSourceAsAdminCreator(MavenProject mavenProject, Log log) {
-        super(mavenProject, log);
+    public DataSourceAsAdminCreator(MavenProject mavenProject, Log log, String profile) {
+        super(mavenProject, log, profile);
     }
 
     @Override
-    public void build() throws IOException {
+    public void build() throws IOException, MojoExecutionException {
         var currentPath = mavenProject.getFile().toPath().getParent();
         var postBootPath = currentPath.resolve("post-boot-commands.asadmin");
+        createPostBootPath(postBootPath);
+        insertOption();
+    }
+
+    private void insertOption() throws MojoExecutionException {
+        var model = mavenProject.getOriginalModel();
+        var build = Objects.isNull(profile)
+                ? model.getBuild()
+                : model.getProfiles().stream()
+                  .filter(p -> p.getId().equals(profile))
+                  .findFirst()
+                  .map(Profile::getBuild)
+                  .orElseThrow();
+        var config = build.getPlugins()
+                .stream()
+                .filter(p ->
+                        Strings.CI.equals(p.getGroupId(), "fish.payara.maven.plugins")
+                                && Strings.CI.equals(p.getArtifactId(), "payara-micro-maven-plugin")
+                ).map(ConfigurationContainer::getConfiguration)
+                .map(Xpp3Dom.class::cast)
+                .findFirst()
+                .orElseThrow();
+        var commandLineOptions = config.getChild("commandLineOptions");
+        var options = commandLineOptions.getChildren("option");
+        if (options == null)
+            throw new MojoExecutionException("commandLineOptions must have at least one option child");
+        var notFound = Arrays.stream(options)
+                .filter(option -> {
+                    var key = option.getChild("key");
+                    if (key == null)
+                        return false;
+                    return key.getValue().equals("--postbootcommandfile");
+                }).findFirst()
+                .isEmpty();
+        if (notFound) {
+            var newOption = new Xpp3Dom("option");
+            var keyTag = new Xpp3Dom("key");
+            keyTag.setValue("--postbootcommandfile");
+
+            var valueTag = new Xpp3Dom("value");
+            valueTag.setValue("post-boot-commands.asadmin");
+
+            newOption.addChild(keyTag);
+            newOption.addChild(valueTag);
+            commandLineOptions.addChild(newOption);
+        }
+    }
+
+    private void createPostBootPath(Path postBootPath) throws IOException {
         log.debug("Creating %s file".formatted(postBootPath));
         var properties = getDataSourceParameters();
         var commands = new StringBuilder();
-        commands.append("create-jdbc-connection-pool  ");
+        commands.append("create-jdbc-connection-pool ");
         commands.append("--restype javax.sql.DataSource ");
         commands.append("--datasourceclassname %s ".formatted(properties.get(CLASS_NAME)));
         commands.append("--property \"");
         properties.entrySet()
-            .stream()
-            .filter(entry -> !Set.of(CLASS_NAME, NAME).contains(entry.getKey()))
-            .forEach((entry) -> commands.append(entry.getKey())
-                .append("=")
-                .append(replaceColons((String) entry.getValue()))
-                .append(":"));
+                .stream()
+                .filter(entry -> !Set.of(CLASS_NAME, NAME).contains(entry.getKey()))
+                .forEach((entry) -> commands.append(entry.getKey())
+                        .append("=")
+                        .append(replaceSpecialCharacters((String) entry.getValue()))
+                        .append(":"));
         commands.deleteCharAt(commands.length() - 1);
         commands.append("\" ");
+        var name = String.valueOf(getDataSourceParameters().get(NAME));
+        var dataSourceName = StringUtils.substringAfterLast(name, "/") + "Pool";
+        commands.append(dataSourceName);
+        commands.append(System.lineSeparator());
+
+        commands.append("create-jdbc-resource ");
+        commands.append("--connectionpoolid %s ".formatted(dataSourceName));
+        commands.append(name);
 
         Files.writeString(postBootPath, commands.toString());
-
     }
 
-    private static String replaceColons(String value) {
-        return Strings.CS.replace(value, ":", "\\\\:");
+    private static String replaceSpecialCharacters(String value) {
+        String[] searchList = {":", "=", ";"};
+        String[] replaceList = {"\\:", "\\=", "\\;"};
+        return StringUtils.replaceEach(value, searchList, replaceList);
     }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreator.java
@@ -18,14 +18,17 @@ package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Abstract class for creating a data source.
@@ -53,7 +56,7 @@ public abstract class DataSourceCreator {
 
     protected String profile;
 
-    public DataSourceCreator(MavenProject mavenProject, Log log){
+    public DataSourceCreator(MavenProject mavenProject, Log log) {
         this.log = log;
         this.mavenProject = mavenProject;
         this.profile = null;
@@ -100,11 +103,7 @@ public abstract class DataSourceCreator {
                     properties.put(key, switch (value.getValueType()) {
                         case STRING -> ((JsonString) value).getString();
                         case NUMBER -> ((JsonNumber) value).intValue();
-                        case ARRAY -> value.asJsonArray()
-                                           .stream()
-                                           .map(JsonString.class::cast)
-                                           .map(JsonString::getString)
-                                           .toList();
+                        case ARRAY -> convertArrayToList(value);
                         default -> value;
                     });
 
@@ -112,6 +111,30 @@ public abstract class DataSourceCreator {
             });
         });
         return properties;
+    }
+
+    private static List<LinkedHashMap<String, Object>> convertArrayToList(JsonValue value) {
+        return value.asJsonArray()
+                .stream()
+                .map(JsonObject.class::cast)
+                .map(jsonObject -> jsonObject.entrySet()
+                        .stream()
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                entry -> getJsonValue(entry.getValue()),
+                                (left, right) -> right,
+                                LinkedHashMap::new
+                        ))
+                )
+                .toList();
+    }
+
+    private static Object getJsonValue(JsonValue value) {
+        return switch (value.getValueType()) {
+            case STRING -> ((JsonString) value).getString();
+            case NUMBER -> ((JsonNumber) value).intValue();
+            default -> value;
+        };
     }
 
     /**

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreator.java
@@ -18,6 +18,7 @@ package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
@@ -50,15 +51,25 @@ public abstract class DataSourceCreator {
      */
     protected JsonObject dataSourceParameters;
 
+    protected String profile;
+
+    public DataSourceCreator(MavenProject mavenProject, Log log){
+        this.log = log;
+        this.mavenProject = mavenProject;
+        this.profile = null;
+    }
+
     /**
      * Constructor for DataSourceCreator.
      *
      * @param mavenProject the Maven project
      * @param log          the logger
+     * @param profile      the profile name
      */
-    public DataSourceCreator(MavenProject mavenProject, Log log) {
+    public DataSourceCreator(MavenProject mavenProject, Log log, String profile) {
         this.log = log;
         this.mavenProject = mavenProject;
+        this.profile = profile;
     }
 
     /**
@@ -111,5 +122,5 @@ public abstract class DataSourceCreator {
      *
      * @throws IOException if an I/O error occurs
      */
-    public abstract void build() throws IOException;
+    public abstract void build() throws IOException, MojoExecutionException;
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactory.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactory.java
@@ -29,20 +29,21 @@ public class DataSourceCreatorFactory {
     }
 
     /**
-     * Returns an Optional containing a DataSourceCreator based on the given declaration.
+     * Returns an Optional containing a DataSourceCreator based on the given
+     * declaration.
      *
      * @param mavenProject the Maven project
      * @param log          the logger
      * @param declare      the type of data source declaration
-     * @return an Optional containing a DataSourceCreator if the declaration matches, otherwise an empty Optional
+     * @return an Optional containing a DataSourceCreator if the declaration
+     *         matches, otherwise an empty Optional
      */
     public static Optional<DataSourceCreator> getDataSourceCreator(MavenProject mavenProject, Log log, String declare) {
-        if (declare.equals(Constants.DATASOURCE_DECLARE_WEB)) {
-            return Optional.of(new DataSourceWebCreator(mavenProject, log));
-        }
-        if (declare.equals(Constants.DATASOURCE_DECLARE_CLASS)) {
-            return Optional.of(new DataSourceClassCreator(mavenProject, log));
-        }
-        return Optional.empty();
+        return switch (declare) {
+            case Constants.DATASOURCE_DECLARE_WEB -> Optional.of(new DataSourceWebCreator(mavenProject, log));
+            case Constants.DATASOURCE_DECLARE_CLASS -> Optional.of(new DataSourceClassCreator(mavenProject, log));
+            case Constants.DATASOURCE_DECLARE_ASADMIN -> Optional.of(new DataSourceAsAdminCreator(mavenProject, log));
+            default -> Optional.empty();
+        };
     }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactory.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactory.java
@@ -35,15 +35,20 @@ public class DataSourceCreatorFactory {
      * @param mavenProject the Maven project
      * @param log          the logger
      * @param declare      the type of data source declaration
+     * @param profile      the profile name
      * @return an Optional containing a DataSourceCreator if the declaration
-     *         matches, otherwise an empty Optional
+     * matches, otherwise an empty Optional
      */
-    public static Optional<DataSourceCreator> getDataSourceCreator(MavenProject mavenProject, Log log, String declare) {
+    public static Optional<DataSourceCreator> getDataSourceCreator(MavenProject mavenProject, Log log, String declare, String profile) {
         return switch (declare) {
             case Constants.DATASOURCE_DECLARE_WEB -> Optional.of(new DataSourceWebCreator(mavenProject, log));
             case Constants.DATASOURCE_DECLARE_CLASS -> Optional.of(new DataSourceClassCreator(mavenProject, log));
-            case Constants.DATASOURCE_DECLARE_ASADMIN -> Optional.of(new DataSourceAsAdminCreator(mavenProject, log));
+            case Constants.DATASOURCE_DECLARE_ASADMIN -> Optional.of(new DataSourceAsAdminCreator(mavenProject, log, profile));
             default -> Optional.empty();
         };
+    }
+
+    public static Optional<DataSourceCreator> getDataSourceCreator(MavenProject mavenProject, Log log, String declare ) {
+        return getDataSourceCreator(mavenProject,log,declare,null);
     }
 }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceWebCreator.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceWebCreator.java
@@ -22,32 +22,32 @@ import org.apache.maven.project.MavenProject;
 import java.io.IOException;
 
 /**
- * Clase responsable de crear el DataSource en un contexto web.
+ * Class responsible for creating the DataSource in a web context.
  * <p>
- * Esta clase extiende {@link DataSourceCreator} y proporciona la implementación
- * para agregar la configuración del DataSource al archivo `web.xml` de un proyecto Jakarta EE.
- * Utiliza la utilidad {@link WebXmlUtil} para manejar las operaciones relacionadas con el archivo `web.xml`.
+ * This class extends {@link DataSourceCreator} and provides the implementation
+ * for adding the DataSource configuration to the `web.xml` file of a Jakarta EE project.
+ * It uses the {@link WebXmlUtil} utility to handle operations related to the `web.xml` file.
  * </p>
  */
 public class DataSourceWebCreator extends DataSourceCreator {
 
 
     /**
-     * Constructor de la clase DataSourceWebCreator.
+     * Creates a DataSourceWebCreator instance.
      *
-     * @param mavenProject el proyecto Maven actual
-     * @param log          el logger para registrar mensajes
+     * @param mavenProject the current Maven project
+     * @param log          the logger used to record messages
      */
     public DataSourceWebCreator(MavenProject mavenProject, Log log) {
         super(mavenProject, log);
     }
 
     /**
-     * Construye y configura el DataSource en el archivo `web.xml`.
+     * Builds and configures the DataSource in the `web.xml` file.
      * <p>
-     * Este método verifica la existencia del archivo `web.xml` en el proyecto actual,
-     * obtiene los parámetros del DataSource y los agrega al archivo. Finalmente, guarda
-     * los cambios realizados en el archivo `web.xml`.
+     * This method checks whether the `web.xml` file exists in the current project,
+     * obtains the DataSource parameters, and adds them to the file. Finally, it saves
+     * the changes made to the `web.xml` file.
      * </p>
      */
     @Override
@@ -57,7 +57,6 @@ public class DataSourceWebCreator extends DataSourceCreator {
         webXmlUtil.checkExistsFile(mavenProject, log)
                   .ifPresent(document -> {
                       var properties = getDataSourceParameters();
-                      var currentPath = mavenProject.getBasedir().toPath();
                       webXmlUtil.addDataSource(document, log, properties);
                       webXmlUtil.saveDocument(mavenProject, document, log);
                   });

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/arch/AddDomainModelsMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/arch/AddDomainModelsMojo.java
@@ -104,7 +104,8 @@ public class AddDomainModelsMojo extends AbstractMojo {
         try {
             var log = getLog();
             init();
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
             var formsPath = validateFile(entitiesFile);
             var architectureHelper = ArchitectureHelper.getInstance();
             architectureHelper.checkDependency(mavenProject, log, jakartaEeVersion);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojo.java
@@ -95,7 +95,8 @@ public class AddFacesMojo extends AbstractMojo {
         try {
             MavenProject fullProject = MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject);
 
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
             log.info("Executing: welcome-file:%s".formatted(welcomeFile));
             log.debug("Project name:%s".formatted(mavenProject.getName()));
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojo.java
@@ -68,7 +68,8 @@ public class AddValidationApiMojo extends AbstractMojo {
         try {
             MavenProject fullProject = MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject);
 
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
 
             jakartaEeHelper.addJakartaValidationApiDependency(mavenProject, log, jakartaEeVersion);
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojo.java
@@ -88,7 +88,8 @@ public class AddPayaraMicroMojo extends AbstractMojo {
 
             MavenProject fullProject = MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject);
 
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
 
             PayaraMicroHelper.getInstance().addPlugin(mavenProject, getLog(), profileId, jakartaEeVersion);
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddAbstractPersistenceMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddAbstractPersistenceMojo.java
@@ -35,10 +35,9 @@ import org.apache.maven.project.ProjectBuildingException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.CLASS_NAME;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_WEB;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.*;
 import static com.apuntesdejava.jakartacoffeebuilder.util.DataSourceUtil.validateDataSourceName;
 
 /**
@@ -52,51 +51,51 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
      * The current Maven project instance. This is automatically injected by Maven.
      */
     @Parameter(defaultValue = "${project}",
-        readonly = true)
+            readonly = true)
     protected MavenProject mavenProject;
     /**
      * The JNDI name for the data source.
      */
     @Parameter(
-        property = "datasource-name",
-        required = true,
-        defaultValue = "defaultDatasource"
+            property = "datasource-name",
+            required = true,
+            defaultValue = "defaultDatasource"
     )
     protected String datasourceName;
     /**
      * The JDBC URL for the database connection.
      */
     @Parameter(
-        property = "url",
-        defaultValue = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
+            property = "url",
+            defaultValue = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
     )
     protected String url;
     /**
      * The password for the database user.
      */
     @Parameter(
-        property = "password"
+            property = "password"
     )
     protected String password;
     /**
      * The username for the database connection.
      */
     @Parameter(
-        property = "user"
+            property = "user"
     )
     protected String user;
     /**
      * The database server name. Used for data sources that require it.
      */
     @Parameter(
-        property = "server-name"
+            property = "server-name"
     )
     protected String serverName;
     /**
      * The port number for the database server.
      */
     @Parameter(
-        property = "port-number"
+            property = "port-number"
     )
     protected Integer portNumber;
     /**
@@ -104,7 +103,7 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
      * (e.g., "prop1=value1,prop2=value2").
      */
     @Parameter(
-        property = "properties"
+            property = PROPERTIES
     )
     protected String properties;
     /**
@@ -112,9 +111,9 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
      * For example, 'web' for web.xml or a server-specific location.
      */
     @Parameter(
-        property = "declare",
-        required = true,
-        defaultValue = DATASOURCE_DECLARE_WEB
+            property = "declare",
+            required = true,
+            defaultValue = DATASOURCE_DECLARE_WEB
     )
     protected String declare;
 
@@ -128,9 +127,9 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
      * The current Maven session. This is automatically injected by Maven.
      */
     @Parameter(
-        defaultValue = "${session}",
-        readonly = true,
-        required = true
+            defaultValue = "${session}",
+            readonly = true,
+            required = true
     )
     protected MavenSession mavenSession;
 
@@ -138,8 +137,8 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
      * The name of the persistence unit to be created or updated in the {@code persistence.xml} file.
      */
     @Parameter(
-        defaultValue = "defaultPU",
-        property = "persistence-unit-name"
+            defaultValue = "defaultPU",
+            property = "persistence-unit-name"
     )
     protected String persistenceUnitName;
     /**
@@ -157,7 +156,7 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
     /**
      * Constructor default
      */
-    public AddAbstractPersistenceMojo(){
+    public AddAbstractPersistenceMojo() {
 
     }
 
@@ -181,7 +180,7 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
     protected JsonObject getDataSourceParameters() {
         datasourceName = validateDataSourceName(declare, datasourceName);
         var jsonBuilder = Json.createObjectBuilder()
-            .add(NAME, datasourceName);
+                .add(NAME, datasourceName);
 
         if (StringUtils.isNotBlank(serverName)) {
             jsonBuilder.add("serverName", serverName);
@@ -200,8 +199,15 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
         }
         if (StringUtils.isNotBlank(properties)) {
             var propertiesBuilder = Json.createArrayBuilder();
-            Arrays.stream(properties.split(",")).forEach(propertiesBuilder::add);
-            jsonBuilder.add("properties", propertiesBuilder);
+            Arrays.stream(properties.split(","))
+                    .map(item -> item.split(":"))
+                    .map(item -> Json.createObjectBuilder(
+                            Map.of(
+                                    NAME, item[0],
+                                    VALUE, Json.createValue(item[1])
+                            )))
+                    .forEach(propertiesBuilder::add);
+            jsonBuilder.add(PROPERTIES, propertiesBuilder);
         }
         return jsonBuilder.build();
     }
@@ -217,9 +223,9 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
         var log = getLog();
         if (StringUtils.isNotBlank(persistenceUnitName)) {
             PersistenceXmlHelper
-                .getInstance()
-                .addDataSourceToPersistenceXml(fullProject, log, persistenceUnitName,
-                    json.getString(NAME));
+                    .getInstance()
+                    .addDataSourceToPersistenceXml(fullProject, log, persistenceUnitName,
+                            json.getString(NAME));
         }
     }
 
@@ -235,40 +241,40 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
     protected void addDataSourceConfiguration(Log log, JsonObject json) throws ProjectBuildingException, IOException {
         var jakartaEeHelper = JakartaEeHelper.getInstance();
         CoffeeBuilderUtil.getJdbcConfiguration(url)
-            .ifPresent(definition -> {
-                jakartaEeHelper.checkDataDependencies(fullProject, log, definition);
-                jakartaEeHelper.addDataSource(fullProject, log, declare,
-                    getDataSourceProperties(json, definition.getString("dataSourceClass")),
-                        profile);
-            });
+                .ifPresent(definition -> {
+                    jakartaEeHelper.checkDataDependencies(fullProject, log, definition);
+                    jakartaEeHelper.addDataSource(fullProject, log, declare,
+                            getDataSourceProperties(json, definition.getString("dataSourceClass")),
+                            profile);
+                });
 
 //        CoffeeBuilderUtil.updateProjectConfiguration(mavenProject.getFile().toPath().getParent(), "jdbc", json);
     }
 
     private JsonObject getDataSourceProperties(JsonObject json, String className) {
         var newValues = Json.createObjectBuilder(json)
-            .add(CLASS_NAME, className).build();
+                .add(CLASS_NAME, className).build();
         var dataSourceProps = Json.createObjectBuilder();
 
         List<String> datasourceProperties = Arrays.asList(
-            "description",
-            "name",
-            "className",
-            "serverName",
-            "portNumber",
-            "databaseName",
-            "url",
-            "user",
-            "password",
-            "property",
-            "loginTimeout",
-            "transactional",
-            "isolationLevel",
-            "initialPoolSize",
-            "maxPoolSize",
-            "minPoolSize",
-            "maxIdleTime",
-            "maxStatements");
+                "description",
+                "name",
+                "className",
+                "serverName",
+                "portNumber",
+                "databaseName",
+                "url",
+                "user",
+                "password",
+                "property",
+                "loginTimeout",
+                "transactional",
+                "isolationLevel",
+                "initialPoolSize",
+                "maxPoolSize",
+                "minPoolSize",
+                "maxIdleTime",
+                "maxStatements");
         datasourceProperties.stream().filter(newValues::containsKey).forEach(prop -> {
             var value = newValues.get(prop);
             var type = value.getValueType();
@@ -278,6 +284,9 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
                 dataSourceProps.add(prop, newValues.getString(prop));
             }
         });
+        if (newValues.containsKey(PROPERTIES) && !newValues.getJsonArray(PROPERTIES).isEmpty()) {
+            dataSourceProps.add(PROPERTIES, newValues.getJsonArray(PROPERTIES));
+        }
         return dataSourceProps.build();
     }
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddAbstractPersistenceMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddAbstractPersistenceMojo.java
@@ -148,6 +148,12 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
      */
     protected MavenProject fullProject;
 
+
+    @Parameter(
+            property = "profile"
+    )
+    protected String profile;
+
     /**
      * Constructor default
      */
@@ -232,8 +238,8 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
             .ifPresent(definition -> {
                 jakartaEeHelper.checkDataDependencies(fullProject, log, definition);
                 jakartaEeHelper.addDataSource(fullProject, log, declare,
-                    getDataSourceProperties(json, definition.getString("dataSourceClass"))
-                );
+                    getDataSourceProperties(json, definition.getString("dataSourceClass")),
+                        profile);
             });
 
 //        CoffeeBuilderUtil.updateProjectConfiguration(mavenProject.getFile().toPath().getParent(), "jdbc", json);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddAbstractPersistenceMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddAbstractPersistenceMojo.java
@@ -240,7 +240,7 @@ public abstract class AddAbstractPersistenceMojo extends AbstractMojo {
      */
     protected void addDataSourceConfiguration(Log log, JsonObject json) throws ProjectBuildingException, IOException {
         var jakartaEeHelper = JakartaEeHelper.getInstance();
-        CoffeeBuilderUtil.getJdbcConfiguration(url)
+        CoffeeBuilderUtil.getJdbcConfiguration(log,url)
                 .ifPresent(definition -> {
                     jakartaEeHelper.checkDataDependencies(fullProject, log, definition);
                     jakartaEeHelper.addDataSource(fullProject, log, declare,

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddEntitiesMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddEntitiesMojo.java
@@ -110,7 +110,7 @@ public class AddEntitiesMojo extends AbstractMojo {
             var persistenceXmlPath = JakartaEeHelper.getInstance()
                     .getPersistenceXmlPath(mavenProject)
                     .orElseThrow( ()-> new FileNotFoundException("persistence.xml file not found"));
-            JakartaPersistenceHelper.getInstance()
+            JakartaPersistenceHelper.getInstance(log)
                                     .addEntities(mavenProject, log, entitiesFile.toPath(), persistenceXmlPath);
         } catch (IOException | MojoFailureException ex) {
             throw new MojoExecutionException("Error adding entities", ex);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojo.java
@@ -103,7 +103,8 @@ public class AddPersistenceMojo extends AddAbstractPersistenceMojo {
     private void checkDependency(Log log) throws MojoExecutionException {
         log.debug("checking Jakarta Persistence dependency");
         try {
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
 
             var jakartaEeHelper = JakartaEeHelper.getInstance();
             if (jakartaEeHelper.hasNotJakartaCdiDependency(fullProject, log)) {

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojo.java
@@ -115,7 +115,7 @@ public class AddPersistenceMojo extends AddAbstractPersistenceMojo {
             }
             if (Strings.CI.equals(jakartaEeVersion, JAKARTAEE_VERSION_10))
                 jakartaEeHelper.addPersistenceClassProvider(mavenProject, log);
-            CoffeeBuilderUtil.getJdbcConfiguration(url)
+            CoffeeBuilderUtil.getJdbcConfiguration(log,url)
                 .ifPresent(definition
                     -> jakartaEeHelper.checkDataDependencies(mavenProject, log, definition));
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
@@ -127,7 +127,6 @@ public class CreateOpenApiMojo extends AbstractMojo {
             var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
                     .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
 
-            jakartaEeHelper.addJacksonDependency(mavenProject, log);
             jakartaEeHelper.addMicroprofileOpenApiApiDependency(mavenProject, log);
             jakartaEeHelper.addJakartaValidationApiDependency(mavenProject, log, jakartaEeVersion);
             jakartaEeHelper.addHelperGenerateSource(mavenProject, log);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojo.java
@@ -124,7 +124,8 @@ public class CreateOpenApiMojo extends AbstractMojo {
         try {
             MavenProject fullProject = MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject);
 
-            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log).orElseThrow();
+            var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(fullProject, log)
+                    .orElseThrow(() -> new MojoExecutionException("Jakarta EE dependency not found. Please ensure it is present in your project."));
 
             jakartaEeHelper.addJacksonDependency(mavenProject, log);
             jakartaEeHelper.addMicroprofileOpenApiApiDependency(mavenProject, log);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/CoffeeBuilderUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/CoffeeBuilderUtil.java
@@ -19,6 +19,7 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.logging.Log;
 
 import java.io.IOException;
 import java.util.Map;
@@ -47,13 +48,14 @@ public class CoffeeBuilderUtil {
     /**
      * Retrieves a specific dependency configuration from a remote repository.
      *
+     * @param log   The Maven logger for logging request details.
      * @param name The name of the dependency to retrieve (e.g., "maven-compiler-plugin").
      * @return An {@link Optional} containing the dependency's configuration as a {@link JsonObject},
      * or empty if not found.
      * @throws IOException if an I/O error occurs during the HTTP request.
      */
-    public static Optional<JsonObject> getDependencyConfiguration(String name) throws IOException {
-        var response = HttpUtil.getContent(HttpUtil.getUrl(Constants.DEPENDENCIES_URL),
+    public static Optional<JsonObject> getDependencyConfiguration(Log log, String name) throws IOException {
+        var response = HttpUtil.getContent(log, HttpUtil.getUrl(Constants.DEPENDENCIES_URL),
             STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
         return Optional.ofNullable(response.getJsonObject(name));
     }
@@ -61,13 +63,14 @@ public class CoffeeBuilderUtil {
     /**
      * Retrieves a specific server definition from a remote repository.
      *
+     * @param log   The Maven logger for logging request details.
      * @param name The name of the server to retrieve (e.g., "payara").
      * @return An {@link Optional} containing the server's definition as a {@link JsonObject},
      * or empty if not found.
      * @throws IOException if an I/O error occurs during the HTTP request.
      */
-    public static Optional<JsonObject> getServerDefinition(String name) throws IOException {
-        var response = HttpUtil.getContent(HttpUtil.getUrl(Constants.SERVERS_URL),
+    public static Optional<JsonObject> getServerDefinition(Log log, String name) throws IOException {
+        var response = HttpUtil.getContent(log, HttpUtil.getUrl(Constants.SERVERS_URL),
             STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
         return Optional.ofNullable(response.getJsonObject(name));
     }
@@ -78,9 +81,9 @@ public class CoffeeBuilderUtil {
      * @return An {@link Optional} containing the complete set of specification definitions.
      * @throws IOException if an I/O error occurs during the HTTP request.
      */
-    public static Optional<JsonObject> getSpecificationsDefinitions() throws IOException {
+    public static Optional<JsonObject> getSpecificationsDefinitions(Log log) throws IOException {
         return Optional.ofNullable(
-            HttpUtil.getContent(HttpUtil.getUrl(Constants.SPECIFICATIONS_URL),
+            HttpUtil.getContent(log, HttpUtil.getUrl(Constants.SPECIFICATIONS_URL),
                 STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER)
         );
     }
@@ -91,9 +94,9 @@ public class CoffeeBuilderUtil {
      * @return An {@link Optional} containing the complete set of class definitions.
      * @throws IOException if an I/O error occurs during the HTTP request.
      */
-    public static Optional<JsonObject> getClassesDefinitions() throws IOException {
+    public static Optional<JsonObject> getClassesDefinitions(Log log) throws IOException {
         return Optional.ofNullable(
-            HttpUtil.getContent(HttpUtil.getUrl(Constants.CLASSES_DEFINITIONS),
+            HttpUtil.getContent(log, HttpUtil.getUrl(Constants.CLASSES_DEFINITIONS),
                 STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER)
         );
     }
@@ -104,9 +107,9 @@ public class CoffeeBuilderUtil {
      * @return An {@link Optional} containing the OpenAPI generator configuration.
      * @throws IOException if an I/O error occurs during the HTTP request.
      */
-    public static Optional<JsonObject> getOpenApiGeneratorConfiguration() throws IOException {
+    public static Optional<JsonObject> getOpenApiGeneratorConfiguration(Log log) throws IOException {
         return Optional.ofNullable(
-            HttpUtil.getContent(HttpUtil.getUrl(Constants.OPEN_API_GENERATOR_CONFIGURATION),
+            HttpUtil.getContent(log, HttpUtil.getUrl(Constants.OPEN_API_GENERATOR_CONFIGURATION),
                 STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER)
         );
     }
@@ -118,8 +121,8 @@ public class CoffeeBuilderUtil {
      * @return An {@link Optional} containing the properties as a {@link JsonArray}, or empty if not found.
      * @throws IOException if an I/O error occurs during the HTTP request.
      */
-    public static Optional<JsonArray> getPropertiesConfiguration(String name) throws IOException {
-        var response = HttpUtil.getContent(HttpUtil.getUrl(Constants.PROPERTIES_URL),
+    public static Optional<JsonArray> getPropertiesConfiguration(Log log, String name) throws IOException {
+        var response = HttpUtil.getContent(log, HttpUtil.getUrl(Constants.PROPERTIES_URL),
             STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
         return Optional.ofNullable(response.getJsonArray(name));
     }
@@ -130,8 +133,8 @@ public class CoffeeBuilderUtil {
      * @return An {@link Optional} containing the dialect configurations.
      * @throws IOException if an I/O error occurs during the HTTP request.
      */
-    public static Optional<JsonObject> getDialectConfiguration() throws IOException {
-        var response = HttpUtil.getContent(HttpUtil.getUrl(Constants.DIALECT_URL),
+    public static Optional<JsonObject> getDialectConfiguration(Log log) throws IOException {
+        var response = HttpUtil.getContent(log, HttpUtil.getUrl(Constants.DIALECT_URL),
             STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
         return Optional.ofNullable(response);
     }
@@ -144,8 +147,8 @@ public class CoffeeBuilderUtil {
      * @return An {@link Optional} containing the schema definition as a {@link JsonObject}, or empty if not found.
      * @throws IOException if an I/O error occurs during the HTTP request.
      */
-    public static Optional<JsonObject> getSchema(String jakartaEeVersion, String name) throws IOException {
-        var response = HttpUtil.getContent(HttpUtil.getUrl(Constants.SCHEMAS_URL),
+    public static Optional<JsonObject> getSchema(Log log, String jakartaEeVersion, String name) throws IOException {
+        var response = HttpUtil.getContent(log, HttpUtil.getUrl(Constants.SCHEMAS_URL),
             STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER);
         return Optional.ofNullable(response.getJsonObject(jakartaEeVersion).getJsonObject(name));
     }
@@ -158,9 +161,9 @@ public class CoffeeBuilderUtil {
      * @return An {@link Optional} containing the JDBC configuration as a {@link JsonObject}, or empty if not found.
      * @throws IOException if an I/O error occurs while fetching the dialect configuration.
      */
-    public static Optional<JsonObject> getJdbcConfiguration(String url) throws IOException {
+    public static Optional<JsonObject> getJdbcConfiguration(Log log, String url) throws IOException {
         final String dialectKey = StringUtils.substringBetween(url, "jdbc:", ":");
-        return getDialectConfiguration().map(
+        return getDialectConfiguration(log).map(
             dialectConfiguration -> dialectConfiguration.getJsonObject(dialectKey));
 
     }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/Constants.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/Constants.java
@@ -18,8 +18,10 @@ package com.apuntesdejava.jakartacoffeebuilder.util;
 import java.util.Set;
 
 /**
- * Provides a central repository for constant values used throughout the Jakarta Coffee Builder plugin.
- * This class prevents the use of magic strings and provides a single source of truth for shared
+ * Provides a central repository for constant values used throughout the Jakarta
+ * Coffee Builder plugin.
+ * This class prevents the use of magic strings and provides a single source of
+ * truth for shared
  * identifiers, keys, and URLs.
  */
 public final class Constants {
@@ -234,6 +236,11 @@ public final class Constants {
      */
     public static final String DATASOURCE_DECLARE_CLASS = "class";
     /**
+     * Indicates that the datasource should be declared using the Payara asadmin
+     * command.
+     */
+    public static final String DATASOURCE_DECLARE_ASADMIN = "asadmin";
+    /**
      * Indicates a Payara-specific datasource declaration.
      */
     public static final String DATASOURCE_PAYARA = "payara";
@@ -299,7 +306,7 @@ public final class Constants {
      * A set of annotation names that are searched for within field definitions.
      */
     public static final Set<String> SEARCH_ANNOTATIONS_FIELD_KEYS = Set.of("Column", "JoinColumn", "ManyToOne",
-        "ElementCollection");
+            "ElementCollection");
     /**
      * A set of supported strategies for the {@code @GeneratedValue} annotation.
      */

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/Constants.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/Constants.java
@@ -319,6 +319,7 @@ public final class Constants {
      * The artifact ID for the OpenAPI Generator Maven Plugin.
      */
     public static final String OPENAPI_GENERATOR_MAVEN_PLUGIN = "openapi-generator-maven-plugin";
+    public static final String PROPERTIES = "properties";
 
     /**
      * Private constructor to prevent instantiation of this utility class.

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
@@ -14,6 +14,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DEV_BASE_URL;
@@ -58,9 +59,12 @@ public final class HttpUtil {
         var requestUrl = address + (parameters.length == 0 ? EMPTY : ("?" + queryParams));
         LOG.log(System.Logger.Level.DEBUG, () -> "Request URL:" + requestUrl);
 
-        try (var httpClient = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .build()) {
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor();
+             var httpClient = HttpClient.newBuilder()
+                     .executor(executor)
+                     .connectTimeout(Duration.ofSeconds(10))
+                     .build()) {
 
             var httpRequest = HttpRequest.newBuilder()
                     .uri(URI.create(requestUrl))

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
@@ -3,14 +3,16 @@ package com.apuntesdejava.jakartacoffeebuilder.util;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URI;
 import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.function.Function;
 
@@ -49,18 +51,28 @@ public final class HttpUtil {
     public static <T> T getContent(String address,
                                    Function<String, T> converter,
                                    Parameter... parameters) throws IOException {
-        try (final var httpClient = HttpClients.createDefault()) {
-            var queryParams = Arrays.stream(parameters)
-                    .map(p -> p.name() + "=" + URLEncoder.encode(p.value(), StandardCharsets.UTF_8))
-                    .reduce((p1, p2) -> p1 + "&" + p2)
-                    .orElse(EMPTY);
-            var requestUrl = address + (parameters.length == 0 ? EMPTY : ("?" + queryParams));
-            var httpGet = new HttpGet(requestUrl);
-            LOG.log(System.Logger.Level.DEBUG, () -> "Request URL:" + requestUrl);
-            return httpClient.execute(httpGet, response -> {
-                var responseString = EntityUtils.toString(response.getEntity());
-                return converter.apply(responseString);
-            });
+        var queryParams = Arrays.stream(parameters)
+                .map(p -> p.name() + "=" + URLEncoder.encode(p.value(), StandardCharsets.UTF_8))
+                .reduce((p1, p2) -> p1 + "&" + p2)
+                .orElse(EMPTY);
+        var requestUrl = address + (parameters.length == 0 ? EMPTY : ("?" + queryParams));
+        LOG.log(System.Logger.Level.DEBUG, () -> "Request URL:" + requestUrl);
+
+        try (var httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build()) {
+
+            var httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(requestUrl))
+                    .timeout(Duration.ofSeconds(10))
+                    .GET()
+                    .build();
+
+            var response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            return converter.apply(response.body());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("HTTP request interrupted", e);
         }
     }
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtil.java
@@ -3,6 +3,7 @@ package com.apuntesdejava.jakartacoffeebuilder.util;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.maven.plugin.logging.Log;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -30,7 +31,6 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
  */
 public final class HttpUtil {
 
-    private static final System.Logger LOG = System.getLogger(HttpUtil.class.getName());
 
     /**
      * Private constructor to prevent instantiation of this utility class.
@@ -43,13 +43,14 @@ public final class HttpUtil {
      * the response body using a provided converter function.
      *
      * @param <T>        The target type of the response after conversion.
+     * @param log      The Maven logger for logging request details.
      * @param address    The URL for the GET request.
      * @param converter  A {@link Function} that transforms the raw response string into the target type {@code T}.
      * @param parameters An optional varargs array of {@link Parameter} objects to be sent as URL query parameters.
      * @return The converted response of type {@code T}.
      * @throws IOException if an I/O error occurs during the HTTP request.
      */
-    public static <T> T getContent(String address,
+    public static <T> T getContent(Log log, String address,
                                    Function<String, T> converter,
                                    Parameter... parameters) throws IOException {
         var queryParams = Arrays.stream(parameters)
@@ -57,8 +58,7 @@ public final class HttpUtil {
                 .reduce((p1, p2) -> p1 + "&" + p2)
                 .orElse(EMPTY);
         var requestUrl = address + (parameters.length == 0 ? EMPTY : ("?" + queryParams));
-        LOG.log(System.Logger.Level.DEBUG, () -> "Request URL:" + requestUrl);
-
+        log.debug("Request URL: " + requestUrl);
 
         try (var executor = Executors.newVirtualThreadPerTaskExecutor();
              var httpClient = HttpClient.newBuilder()

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/JsonUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/JsonUtil.java
@@ -1,6 +1,7 @@
 package com.apuntesdejava.jakartacoffeebuilder.util;
 
 import jakarta.json.Json;
+import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
@@ -50,13 +51,14 @@ public final class JsonUtil {
      * Returns {@code null} for {@code JsonValue.ValueType.NULL}.
      */
     public static Object getJsonValue(JsonValue jsonValue) {
-        return switch (jsonValue.getValueType()) {
-            case ARRAY -> jsonValue.asJsonArray();
-            case OBJECT -> jsonValue.asJsonObject();
-            case STRING -> ((JsonString) jsonValue).getString();
-            case NUMBER -> ((JsonNumber) jsonValue).numberValue();
-            case TRUE -> true;
-            case FALSE -> false;
+        return switch (jsonValue) {
+            case JsonString s -> s.getString();
+            case JsonNumber n -> n.numberValue();
+            case JsonObject o -> o;
+            case JsonArray a -> a;
+            case JsonValue v when v == JsonValue.TRUE -> true;
+            case JsonValue v when v == JsonValue.FALSE -> false;
+            case JsonValue v when v == JsonValue.NULL -> null;
             default -> null;
         };
     }
@@ -111,13 +113,19 @@ public final class JsonUtil {
         jsonObject.forEach((key, value) -> {
             if (allowRepeat || config.getChild(key) == null) {
 
-                switch (value.getValueType()) {
-                    case ARRAY -> evaluateArrayElement(config, log, key, value);
-                    case OBJECT -> evaluateObjectElement(config, log, key, value, allowRepeat);
-                    default -> {
+                switch (value) {
+                    case JsonArray a -> evaluateArrayElement(config, log, key, a);
+                    case JsonObject o -> evaluateObjectElement(config, log, key, o, allowRepeat);
+                    case JsonString s -> {
                         log.debug("---- in value");
                         Xpp3Dom child = new Xpp3Dom(key);
-                        child.setValue(((JsonString) value).getString());
+                        child.setValue(s.getString());
+                        config.addChild(child);
+                    }
+                    default -> {
+                        log.debug("---- in default value");
+                        Xpp3Dom child = new Xpp3Dom(key);
+                        child.setValue(value.toString());
                         config.addChild(child);
                     }
 

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/PomUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/PomUtil.java
@@ -220,8 +220,8 @@ public final class PomUtil {
             var coordinatesSplit = StringUtils.split(coordinates, ":");
             var groupId = coordinatesSplit[0];
             var artifactId = coordinatesSplit[1];
-            var version = coordinatesSplit.length == 3 ? coordinatesSplit[2] : findLatestDependencyVersion(
-                groupId,
+            var version = coordinatesSplit.length == 3
+                    ? coordinatesSplit[2] : findLatestDependencyVersion(log, groupId,
                 artifactId).orElseThrow();
             log.debug("adding dependency %s".formatted(coordinates));
             log.debug("groupId:%s | artifactId:%s | version:%s".formatted(groupId, artifactId,
@@ -236,41 +236,44 @@ public final class PomUtil {
     /**
      * Finds the latest version of a Maven dependency by querying the Maven Central search API.
      *
+     * @param log          The Maven logger.
      * @param groupId    The group ID of the dependency.
      * @param artifactId The artifact ID of the dependency.
      * @return An {@link Optional} containing the latest version string, or empty if not found.
      * @throws IOException if an error occurs during the HTTP request to Maven Central.
      */
-    public static Optional<String> findLatestDependencyVersion(String groupId, String artifactId) throws IOException {
-        return findLatestVersion(groupId, artifactId, "jar");
+    public static Optional<String> findLatestDependencyVersion(Log log, String groupId, String artifactId) throws IOException {
+        return findLatestVersion(log, groupId, artifactId, "jar");
     }
 
     /**
      * Finds the latest version of a Maven plugin by querying the Maven Central search API.
      *
+     * @param log          The Maven logger.
      * @param groupId    The group ID of the plugin.
      * @param artifactId The artifact ID of the plugin.
      * @return An {@link Optional} containing the latest version string, or empty if not found.
      * @throws IOException if an error occurs during the HTTP request to Maven Central.
      */
-    public static Optional<String> findLatestPluginVersion(String groupId, String artifactId) throws IOException {
-        return findLatestVersion(groupId, artifactId, "maven-plugin");
+    public static Optional<String> findLatestPluginVersion(Log log, String groupId, String artifactId) throws IOException {
+        return findLatestVersion(log, groupId, artifactId, "maven-plugin");
     }
 
     /**
      * Finds the latest version of a Maven artifact with a specific packaging type from Maven Central.
      *
+     * @param log          The Maven logger.
      * @param groupId    The group ID of the artifact.
      * @param artifactId The artifact ID of the artifact.
      * @param packaging  The packaging type (e.g., "jar", "maven-plugin").
      * @return An {@link Optional} containing the latest version string, or empty if not found.
      * @throws IOException if an error occurs during the HTTP request.
      */
-    public static Optional<String> findLatestVersion(String groupId,
+    public static Optional<String> findLatestVersion(Log log, String groupId,
                                                      String artifactId,
                                                      String packaging) throws IOException {
         var params = "p:%s AND a:%s AND g:%s".formatted(packaging, artifactId, groupId);
-        var response = HttpUtil.getContent("https://search.maven.org/solrsearch/select",
+        var response = HttpUtil.getContent(log, "https://search.maven.org/solrsearch/select",
             STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER, new HttpUtil.Parameter("q", params));
 
         JsonArray docs = response.getJsonObject("response").getJsonArray("docs");
@@ -283,15 +286,16 @@ public final class PomUtil {
     /**
      * Retrieves detailed information for a specific artifact version from Maven Central.
      *
+     * @param log          The Maven logger.
      * @param groupId    The group ID of the artifact.
      * @param artifactId The artifact ID of the artifact.
      * @param version    The version of the artifact.
      * @return A {@link JsonObject} containing the artifact's information.
      * @throws IOException if an error occurs during the HTTP request.
      */
-    public static JsonObject getArtifactInfo(String groupId, String artifactId, String version) throws IOException {
+    public static JsonObject getArtifactInfo(Log log, String groupId, String artifactId, String version) throws IOException {
         var params = "v:%s AND a:%s AND g:%s".formatted(version, artifactId, groupId);
-        var response = HttpUtil.getContent("https://search.maven.org/solrsearch/select",
+        var response = HttpUtil.getContent(log, "https://search.maven.org/solrsearch/select",
             STRING_TO_JSON_OBJECT_RESPONSE_CONVERTER, new HttpUtil.Parameter("q", params));
         return response.getJsonObject("response").getJsonArray("docs").getJsonObject(0);
     }

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/WebXmlUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/WebXmlUtil.java
@@ -16,7 +16,6 @@
 package com.apuntesdejava.jakartacoffeebuilder.util;
 
 import jakarta.json.JsonObject;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.dom4j.Document;
@@ -26,9 +25,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.JAKARTA_FACES_WEBAPP_FACES_SERVLET;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.NAME;
-import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.VALUE;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.*;
 
 /**
  * Utility class for handling operations related to the `web.xml` file in a Jakarta EE Maven project.
@@ -55,7 +52,7 @@ import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.VALUE;
  * </p>
  */
 public class WebXmlUtil {
-    
+
     private static final String WEB_APP_EXP_SEARCH = "//*[local-name()='web-app']";
 
     private WebXmlUtil() {
@@ -90,13 +87,13 @@ public class WebXmlUtil {
             try {
                 var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(mavenProject, log).orElseThrow();
                 JsonObject schemaDescription = CoffeeBuilderUtil.getSchema(jakartaEeVersion,
-                    "web-app").orElseThrow();
+                        "web-app").orElseThrow();
 
                 var webAppElement = document.addElement("web-app", "https://jakarta.ee/xml/ns/jakartaee");
                 webAppElement.addAttribute("version", schemaDescription.getString("version"));
                 webAppElement.addAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
                 webAppElement.addAttribute("xsi:schemaLocation",
-                    "https://jakarta.ee/xml/ns/jakartaee " + schemaDescription.getString("url"));
+                        "https://jakarta.ee/xml/ns/jakartaee " + schemaDescription.getString("url"));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -121,7 +118,7 @@ public class WebXmlUtil {
         var xmlUtil = XmlUtil.getInstance();
 
         var nodeList = xmlUtil.findElements(document,
-            "//*[local-name()='servlet-class' and text()='%s']".formatted(JAKARTA_FACES_WEBAPP_FACES_SERVLET)).count();
+                "//*[local-name()='servlet-class' and text()='%s']".formatted(JAKARTA_FACES_WEBAPP_FACES_SERVLET)).count();
         if (nodeList == 0) {
             xmlUtil.addElement(document, log, WEB_APP_EXP_SEARCH, "servlet", servlet -> {
                 xmlUtil.addElement(servlet, "description", description);
@@ -159,7 +156,7 @@ public class WebXmlUtil {
         var nodeList = xmlUtil.findElements(document, "//*[local-name()='welcome-file']").count();
         if (nodeList == 0) {
             xmlUtil.addElement(document, log, WEB_APP_EXP_SEARCH, "welcome-file-list",
-                (element) -> xmlUtil.addElement(element, "welcome-file", welcomeFile));
+                    (element) -> xmlUtil.addElement(element, "welcome-file", welcomeFile));
         }
     }
 
@@ -174,15 +171,14 @@ public class WebXmlUtil {
     public void addDataSource(Document document, Log log, Map<String, Object> properties) {
         var xmlUtil = XmlUtil.getInstance();
         if (xmlUtil.findElementsStream(document,
-            "//*[local-name()='data-source'][*[local-name()='name' and text()='%s']]".formatted(properties.get(NAME))).findFirst().isEmpty()) {
+                "//*[local-name()='data-source'][*[local-name()='name' and text()='%s']]".formatted(properties.get(NAME))).findFirst().isEmpty()) {
             var datasourceElem = xmlUtil.addElement(document, log, "web-app", "data-source");
             properties.forEach((key, value) -> {
                 if (value instanceof Collection<?> collection) {
-                    collection.forEach(item -> {
+                    collection.stream().map(Map.class::cast).forEach(item -> {
                         var propertyElem = xmlUtil.addElement(datasourceElem, "property");
-                        var values = StringUtils.split(item.toString(), "=");
-                        xmlUtil.addElement(propertyElem, NAME, values[0]);
-                        xmlUtil.addElement(propertyElem, VALUE, values[1]);
+                        xmlUtil.addElement(propertyElem, NAME, item.get(NAME).toString());
+                        xmlUtil.addElement(propertyElem, VALUE, item.get(VALUE).toString());
                     });
                 } else {
                     var newKey = StringsUtil.camelCaseToParamCase(key);

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/WebXmlUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/WebXmlUtil.java
@@ -86,7 +86,7 @@ public class WebXmlUtil {
         return XmlUtil.getInstance().getDocument(log, webXmlPath, document -> {
             try {
                 var jakartaEeVersion = PomUtil.getJakartaEeCurrentVersion(mavenProject, log).orElseThrow();
-                JsonObject schemaDescription = CoffeeBuilderUtil.getSchema(jakartaEeVersion,
+                JsonObject schemaDescription = CoffeeBuilderUtil.getSchema(log,jakartaEeVersion,
                         "web-app").orElseThrow();
 
                 var webAppElement = document.addElement("web-app", "https://jakarta.ee/xml/ns/jakartaee");

--- a/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/XmlUtil.java
+++ b/src/main/java/com/apuntesdejava/jakartacoffeebuilder/util/XmlUtil.java
@@ -232,8 +232,8 @@ public class XmlUtil {
             }
             Files.createDirectories(path.getParent());
             var doc = createDocumentType == null
-                ? DocumentHelper.createDocument()
-                : createDocumentType.get();
+                    ? DocumentHelper.createDocument()
+                    : createDocumentType.get();
             Optional.ofNullable(postCreate).ifPresent(p -> p.accept(doc));
             return Optional.of(doc);
         } catch (IOException | DocumentException e) {
@@ -400,7 +400,8 @@ public class XmlUtil {
      * @param tagNameToRemove the tag name of the child element to be removed
      */
     public void removeElement(Element element, String tagNameToRemove) {
-        Optional.ofNullable((Element) element.selectSingleNode(tagNameToRemove)).ifPresent(element::remove);
+        Optional.ofNullable((Element) element.selectSingleNode("./*[local-name()='%s']".formatted(tagNameToRemove)))
+                .ifPresent(element::remove);
     }
 
     /**

--- a/src/main/resources/freemaker/java/Mapper.ftl
+++ b/src/main/resources/freemaker/java/Mapper.ftl
@@ -6,8 +6,9 @@ import ${importItem};
     </#list>
 </#if>
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants.ComponentModel;
 
-@Mapper(componentModel = "jakarta")
+@Mapper(componentModel = ComponentModel.JAKARTA_CDI)
 public interface ${className} {
     ${modelName}Entity modelToEntity(${modelName} model);
 

--- a/src/main/resources/openapi-templates/enumOuterClass.mustache
+++ b/src/main/resources/openapi-templates/enumOuterClass.mustache
@@ -1,0 +1,36 @@
+/**
+ * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+{{#isDeprecated}}
+ * @deprecated
+{{/isDeprecated}}
+ */
+{{>generatedAnnotation}}
+
+{{#isDeprecated}}
+@Deprecated
+
+{{/isDeprecated}}{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+  {{#allowableValues}}{{#enumVars}}
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+
+  private {{{dataType}}} value;
+
+  {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+    this.value = value;
+  }
+
+  public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromString(String s) {
+    for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+      if (java.util.Objects.toString(b.value).equals(s)) {
+        return b;
+      }
+    }
+    {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected string value '" + s + "'");{{/isNullable}}
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+}

--- a/src/main/resources/openapi-templates/pojo.mustache
+++ b/src/main/resources/openapi-templates/pojo.mustache
@@ -1,0 +1,214 @@
+{{#useSwaggerAnnotations}}
+import io.swagger.annotations.*;
+{{/useSwaggerAnnotations}}
+{{#useSwaggerV3Annotations}}
+import io.swagger.v3.oas.annotations.media.Schema;
+{{/useSwaggerV3Annotations}}
+import java.util.Objects;
+{{#withXml}}
+import {{javaxPackage}}.xml.bind.annotation.XmlElement;
+import {{javaxPackage}}.xml.bind.annotation.XmlRootElement;
+import {{javaxPackage}}.xml.bind.annotation.XmlAccessType;
+import {{javaxPackage}}.xml.bind.annotation.XmlAccessorType;
+import {{javaxPackage}}.xml.bind.annotation.XmlType;
+import {{javaxPackage}}.xml.bind.annotation.XmlEnum;
+import {{javaxPackage}}.xml.bind.annotation.XmlEnumValue;
+{{/withXml}}
+
+{{#description}}/**
+ * {{.}}
+ {{#isDeprecated}}
+ * @deprecated
+ {{/isDeprecated}}
+ **/{{/description}}
+{{#isDeprecated}}
+@Deprecated
+
+{{/isDeprecated}}{{#useSwaggerAnnotations}}{{#description}}@ApiModel(description = "{{{.}}}"){{/description}}{{/useSwaggerAnnotations}}{{#useSwaggerV3Annotations}}
+@Schema({{#title}}title="{{{.}}}", {{/title}}{{#description}}description="{{{.}}}"{{/description}}{{^description}}description=""{{/description}}{{#isDeprecated}}, deprecated = true{{/isDeprecated}}){{/useSwaggerV3Annotations}}{{#useMicroProfileOpenAPIAnnotations}}
+@org.eclipse.microprofile.openapi.annotations.media.Schema({{#title}}title="{{{.}}}", {{/title}}{{#description}}description="{{{.}}}"{{/description}}{{^description}}description=""{{/description}}{{#isDeprecated}}, deprecated = true{{/isDeprecated}}){{/useMicroProfileOpenAPIAnnotations}}
+{{>generatedAnnotation}}{{>additionalModelTypeAnnotations}}{{>xmlPojoAnnotation}}
+{{#vendorExtensions.x-class-extra-annotation}}
+{{{vendorExtensions.x-class-extra-annotation}}}
+{{/vendorExtensions.x-class-extra-annotation}}
+public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtensions.x-implements}}{{#-first}}implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
+  {{#vars}}
+  {{#isEnum}}
+  {{^isContainer}}
+  {{>enumClass}}
+  {{/isContainer}}
+  {{#isContainer}}
+  {{#mostInnerItems}}
+  {{>enumClass}}
+  {{/mostInnerItems}}
+  {{/isContainer}}
+  {{/isEnum}}
+  {{#vendorExtensions.x-field-extra-annotation}}
+  {{{.}}}
+  {{/vendorExtensions.x-field-extra-annotation}}
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
+  private {{#isContainer}}{{#useBeanValidation}}@Valid {{/useBeanValidation}}{{/isContainer}}{{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  {{/vars}}
+
+  {{#generateBuilders}}
+  {{^additionalProperties}}
+  protected {{classname}}({{classname}}Builder<?, ?> b) {
+    {{#parent}}
+    super(b);
+    {{/parent}}
+    {{#vars}}
+    this.{{name}} = b.{{name}};
+    {{/vars}}
+  }
+
+  {{/additionalProperties}}
+  {{/generateBuilders}}
+  public {{classname}}() {
+  }
+
+  {{#vars}}
+  /**
+   {{#description}}
+   * {{.}}
+   {{/description}}
+   {{#minimum}}
+   * minimum: {{.}}
+   {{/minimum}}
+   {{#maximum}}
+   * maximum: {{.}}
+   {{/maximum}}
+   {{#deprecated}}
+   * @deprecated
+   {{/deprecated}}
+   **/
+  {{#deprecated}}
+  @Deprecated
+  {{/deprecated}}
+  public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
+    this.{{name}} = {{name}};
+    return this;
+  }
+
+  {{#withXml}}
+      @XmlElement(name="{{baseName}}"{{#required}}, required = {{required}}{{/required}})
+  {{/withXml}}
+  {{#deprecated}}
+  /**
+   * @deprecated
+   */
+  @Deprecated
+  {{/deprecated}}
+  {{#vendorExtensions.x-extra-annotation}}{{{vendorExtensions.x-extra-annotation}}}{{/vendorExtensions.x-extra-annotation}}{{#useSwaggerAnnotations}}
+  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/useSwaggerAnnotations}}{{#useSwaggerV3Annotations}}
+  @Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}description = "{{{description}}}"{{#deprecated}}, deprecated = true{{/deprecated}}){{/useSwaggerV3Annotations}}{{#useMicroProfileOpenAPIAnnotations}}
+  @org.eclipse.microprofile.openapi.annotations.media.Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}description = "{{{description}}}"{{#deprecated}}, deprecated = true{{/deprecated}}){{/useMicroProfileOpenAPIAnnotations}}
+  {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}public {{>beanValidatedType}} {{getter}}() {
+    return {{name}};
+  }
+
+  {{#deprecated}}
+  /**
+   * @deprecated
+   */
+  @Deprecated
+  {{/deprecated}}
+  {{#vendorExtensions.x-setter-extra-annotation}}{{{vendorExtensions.x-setter-extra-annotation}}}
+  {{/vendorExtensions.x-setter-extra-annotation}}public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+    this.{{name}} = {{name}};
+  }
+
+  {{#isArray}}
+  public {{classname}} add{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
+    }
+
+    this.{{name}}.add({{name}}Item);
+    return this;
+  }
+
+  public {{classname}} remove{{nameInPascalCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    if ({{name}}Item != null && this.{{name}} != null) {
+      this.{{name}}.remove({{name}}Item);
+    }
+
+    return this;
+  }
+  {{/isArray}}
+  {{/vars}}
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }{{#hasVars}}
+    {{classname}} {{classVarName}} = ({{classname}}) o;
+    return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{^-last}} &&
+        {{/-last}}{{/vars}}{{#parent}} &&
+        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash({{#vars}}{{name}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class {{classname}} {\n");
+    {{#parent}}sb.append("    ").append(toIndentedString(super.toString())).append("\n");{{/parent}}
+    {{#vars}}sb.append("    {{name}}: ").append({{#isPassword}}"*"{{/isPassword}}{{^isPassword}}toIndentedString({{name}}){{/isPassword}}).append("\n");
+    {{/vars}}sb.append("}");
+    return sb.toString();
+  }
+
+  private String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+
+{{#generateBuilders}}{{^additionalProperties}}
+  public static {{classname}}Builder<?, ?> builder() {
+    return new {{classname}}BuilderImpl();
+  }
+
+  private static final class {{classname}}BuilderImpl extends {{classname}}Builder<{{classname}}, {{classname}}BuilderImpl> {
+
+    @Override
+    protected {{classname}}BuilderImpl self() {
+      return this;
+    }
+
+    @Override
+    public {{classname}} build() {
+      return new {{classname}}(this);
+    }
+  }
+
+  public static abstract class {{classname}}Builder<C extends {{classname}}, B extends {{classname}}Builder<C, B>> {{#parent}}extends {{{.}}}Builder<C, B>{{/parent}} {
+    {{#vars}}
+    private {{#removeAnnotations}}{{{datatypeWithEnum}}}{{/removeAnnotations}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+    {{/vars}}
+  {{^parent}}
+    protected abstract B self();
+
+    public abstract C build();
+    {{/parent}}
+
+    {{#vars}}
+    {{#deprecated}}
+    @Deprecated
+    {{/deprecated}}
+    public B {{name}}({{#removeAnnotations}}{{{datatypeWithEnum}}}{{/removeAnnotations}} {{name}}) {
+      this.{{name}} = {{name}};
+      return self();
+    }
+    {{/vars}}
+  }{{/additionalProperties}}{{/generateBuilders}}
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactoryTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/helper/datasource/DataSourceCreatorFactoryTest.java
@@ -1,0 +1,56 @@
+package com.apuntesdejava.jakartacoffeebuilder.helper.datasource;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_ASADMIN;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_CLASS;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_WEB;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class DataSourceCreatorFactoryTest {
+
+    private final MavenProject mockProject = mock(MavenProject.class);
+    private final Log mockLog = mock(Log.class);
+
+    @Test
+    @DisplayName("should return DataSourceWebCreator for web.xml declaration")
+    void returnsWebCreatorForWebXml() {
+        Optional<DataSourceCreator> creator = DataSourceCreatorFactory.getDataSourceCreator(
+            mockProject, mockLog, DATASOURCE_DECLARE_WEB);
+        assertTrue(creator.isPresent());
+        assertInstanceOf(DataSourceWebCreator.class, creator.get());
+    }
+
+    @Test
+    @DisplayName("should return DataSourceClassCreator for class declaration")
+    void returnsClassCreatorForClass() {
+        Optional<DataSourceCreator> creator = DataSourceCreatorFactory.getDataSourceCreator(
+            mockProject, mockLog, DATASOURCE_DECLARE_CLASS);
+        assertTrue(creator.isPresent());
+        assertInstanceOf(DataSourceClassCreator.class, creator.get());
+    }
+
+    @Test
+    @DisplayName("should return DataSourceAsAdminCreator for asadmin declaration")
+    void returnsAsAdminCreatorForAsadmin() {
+        Optional<DataSourceCreator> creator = DataSourceCreatorFactory.getDataSourceCreator(
+            mockProject, mockLog, DATASOURCE_DECLARE_ASADMIN);
+        assertTrue(creator.isPresent());
+        assertInstanceOf(DataSourceAsAdminCreator.class, creator.get());
+    }
+
+    @Test
+    @DisplayName("should return empty Optional for unknown declaration")
+    void returnsEmptyForUnknown() {
+        Optional<DataSourceCreator> creator = DataSourceCreatorFactory.getDataSourceCreator(
+            mockProject, mockLog, "unknown");
+        assertTrue(creator.isEmpty());
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/model/NamespaceContextMapTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/model/NamespaceContextMapTest.java
@@ -1,0 +1,58 @@
+package com.apuntesdejava.jakartacoffeebuilder.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NamespaceContextMapTest {
+
+    private static final String PREFIX = "ns";
+    private static final String URI = "http://example.com/ns";
+
+    private NamespaceContextMap context;
+
+    @BeforeEach
+    void setUp() {
+        context = new NamespaceContextMap(PREFIX, URI);
+    }
+
+    @Test
+    @DisplayName("getNamespaceURI: should return URI for known prefix")
+    void getNamespaceURI_knownPrefix_returnsUri() {
+        assertEquals(URI, context.getNamespaceURI(PREFIX));
+    }
+
+    @Test
+    @DisplayName("getNamespaceURI: should return empty string for unknown prefix")
+    void getNamespaceURI_unknownPrefix_returnsEmpty() {
+        assertEquals("", context.getNamespaceURI("unknown"));
+    }
+
+    @Test
+    @DisplayName("getPrefix: should return prefix for known URI")
+    void getPrefix_knownUri_returnsPrefix() {
+        assertEquals(PREFIX, context.getPrefix(URI));
+    }
+
+    @Test
+    @DisplayName("getPrefix: should return null for unknown URI")
+    void getPrefix_unknownUri_returnsNull() {
+        assertNull(context.getPrefix("http://unknown.com"));
+    }
+
+    @Test
+    @DisplayName("getPrefixes: should return iterator containing the known prefix")
+    void getPrefixes_returnsIteratorWithPrefix() {
+        Iterator<String> prefixes = context.getPrefixes(URI);
+        assertTrue(prefixes.hasNext());
+        assertEquals(PREFIX, prefixes.next());
+        assertFalse(prefixes.hasNext());
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/arch/AddDomainModelsMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/arch/AddDomainModelsMojoTest.java
@@ -1,0 +1,160 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.arch;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.ArchitectureHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.JsonUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddDomainModelsMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddDomainModelsMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JsonUtil> jsonUtilMockedStatic;
+    private MockedStatic<ArchitectureHelper> architectureHelperMockedStatic;
+
+    @Mock
+    private ArchitectureHelper architectureHelperMock;
+
+    private File tempFile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jsonUtilMockedStatic = mockStatic(JsonUtil.class);
+        architectureHelperMockedStatic = mockStatic(ArchitectureHelper.class);
+
+        architectureHelperMockedStatic.when(ArchitectureHelper::getInstance).thenReturn(architectureHelperMock);
+
+        tempFile = File.createTempFile("entities", ".json");
+        tempFile.deleteOnExit();
+
+        java.lang.reflect.Field entitiesFileField = AddDomainModelsMojo.class.getDeclaredField("entitiesFile");
+        entitiesFileField.setAccessible(true);
+        entitiesFileField.set(mojo, tempFile);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jsonUtilMockedStatic.close();
+        architectureHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add domain models successfully")
+    void execute_ValidProjectAndFile_AddsModels() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.of("10.0.0"));
+
+        JsonObject dummyJson = Json.createObjectBuilder().add("test", "data").build();
+        JsonValue dummyJsonValue = org.mockito.Mockito.mock(JsonValue.class);
+        lenient().when(dummyJsonValue.asJsonObject()).thenReturn(dummyJson);
+
+        jsonUtilMockedStatic.when(() -> JsonUtil.readJsonValue(any(Path.class)))
+            .thenReturn(dummyJsonValue);
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(architectureHelperMock).checkDependency(mavenProject, mockLog, "10.0.0");
+        verify(architectureHelperMock).createDtos(mavenProject, mockLog, dummyJson);
+        verify(architectureHelperMock).createMappers(mavenProject, mockLog, dummyJson);
+        verify(architectureHelperMock).createModelRepositoryInterfaces(mavenProject, mockLog, dummyJson);
+        verify(architectureHelperMock).createServices(mavenProject, mockLog, dummyJson);
+
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when entities file does not exist")
+    void execute_MissingFile_ThrowsException() throws Exception {
+        File nonExistent = new File("non-existent-file-12345.json");
+        java.lang.reflect.Field entitiesFileField = AddDomainModelsMojo.class.getDeclaredField("entitiesFile");
+        entitiesFileField.setAccessible(true);
+        entitiesFileField.set(mojo, nonExistent);
+
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.of("10.0.0"));
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("File not found"));
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when Jakarta EE version missing")
+    void execute_MissingJakartaEeVersion_ThrowsException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacePageMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacePageMojoTest.java
@@ -1,0 +1,93 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.faces;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaFacesHelper;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddFacePageMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddFacePageMojo mojo;
+
+    private MockedStatic<JakartaFacesHelper> jakartaFacesHelperMockedStatic;
+
+    @Mock
+    private JakartaFacesHelper jakartaFacesHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        jakartaFacesHelperMockedStatic = mockStatic(JakartaFacesHelper.class);
+        jakartaFacesHelperMockedStatic.when(JakartaFacesHelper::getInstance).thenReturn(jakartaFacesHelperMock);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddFacePageMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jakartaFacesHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add face page without template and with managed bean")
+    void execute_NoTemplateWithBean_AddsFacePage() throws Exception {
+        setField("pageName", "index.xhtml");
+        setField("createManagedBean", true);
+        setField("templateFacelet", null);
+
+        mojo.execute();
+
+        verify(jakartaFacesHelperMock).addFacePage(mavenProject, mockLog, "index.xhtml", true);
+        verify(jakartaFacesHelperMock).createManagedBean(mavenProject, mockLog, "index.xhtml");
+        verify(jakartaFacesHelperMock, never()).addFacePageWithFaceletTemplate(any(),
+            any(),
+            any(),
+            any(),
+            anyBoolean());
+    }
+
+    @Test
+    @DisplayName("execute: should add face page with template and without managed bean")
+    void execute_WithTemplateNoBean_AddsFacePageWithTemplate() throws Exception {
+        setField("pageName", "index.xhtml");
+        setField("createManagedBean", false);
+        setField("templateFacelet", "template.xhtml");
+
+        mojo.execute();
+
+        verify(jakartaFacesHelperMock).addFacePageWithFaceletTemplate(mavenProject,
+            mockLog,
+            "index.xhtml",
+            "template.xhtml",
+            false);
+        verify(jakartaFacesHelperMock, never()).addFacePage(any(), any(), any(), anyBoolean());
+        verify(jakartaFacesHelperMock, never()).createManagedBean(any(), any(), any());
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFaceTemplateMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFaceTemplateMojoTest.java
@@ -1,0 +1,69 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.faces;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaFacesHelper;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddFaceTemplateMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddFaceTemplateMojo mojo;
+
+    private MockedStatic<JakartaFacesHelper> jakartaFacesHelperMockedStatic;
+
+    @Mock
+    private JakartaFacesHelper jakartaFacesHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        jakartaFacesHelperMockedStatic = mockStatic(JakartaFacesHelper.class);
+        jakartaFacesHelperMockedStatic.when(JakartaFacesHelper::getInstance).thenReturn(jakartaFacesHelperMock);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddFaceTemplateMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jakartaFacesHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add face template successfully")
+    void execute_ValidTemplate_AddsTemplate() throws Exception {
+        setField("templateName", "myTemplate");
+        List<String> inserts = Arrays.asList("header", "footer");
+        setField("inserts", inserts);
+
+        mojo.execute();
+
+        verify(jakartaFacesHelperMock).addFaceTemplate(mavenProject, mockLog, "myTemplate", inserts);
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFacesMojoTest.java
@@ -1,0 +1,141 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.faces;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddFacesMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddFacesMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @BeforeEach
+    void setUp() {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add Faces configurations successfully")
+    void execute_ValidProject_AddsConfigurations() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.of("10.0.0"));
+
+        lenient().when(jakartaEeHelperMock.hasJakartaFacesDependency(fullProject, mockLog)).thenReturn(false);
+        lenient().when(jakartaEeHelperMock.hasNotJakartaCdiDependency(fullProject, mockLog)).thenReturn(true);
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).addJakartaFacesDependency(mavenProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addJakartaCdiDependency(mavenProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addJakartaFacesDeclaration(fullProject, mockLog);
+        verify(jakartaEeHelperMock).addWelcomePages(eq(fullProject), any(), eq(mockLog));
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should skip adding dependencies if already present")
+    void execute_DependenciesPresent_SkipsDependencies() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.of("10.0.0"));
+
+        lenient().when(jakartaEeHelperMock.hasJakartaFacesDependency(fullProject, mockLog)).thenReturn(true);
+        lenient().when(jakartaEeHelperMock.hasNotJakartaCdiDependency(fullProject, mockLog)).thenReturn(false);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock, never()).addJakartaFacesDependency(any(), any(), any());
+        verify(jakartaEeHelperMock, never()).addJakartaCdiDependency(any(), any(), any());
+        verify(jakartaEeHelperMock).addJakartaFacesDeclaration(fullProject, mockLog);
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when Jakarta EE version is missing")
+    void execute_MissingJakartaEeVersion_ThrowsMojoExecutionException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+            .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFormsFromEntitiesMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/faces/AddFormsFromEntitiesMojoTest.java
@@ -1,0 +1,131 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.faces;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.PrimeFacesHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddFormsFromEntitiesMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddFormsFromEntitiesMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<PrimeFacesHelper> primeFacesHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private PrimeFacesHelper primeFacesHelperMock;
+
+    private File tempFormsFile;
+    private File tempEntitiesFile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        primeFacesHelperMockedStatic = mockStatic(PrimeFacesHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        primeFacesHelperMockedStatic.when(PrimeFacesHelper::getInstance).thenReturn(primeFacesHelperMock);
+
+        tempFormsFile = File.createTempFile("forms", ".json");
+        tempFormsFile.deleteOnExit();
+
+        tempEntitiesFile = File.createTempFile("entities", ".json");
+        tempEntitiesFile.deleteOnExit();
+
+        setField("formsFile", tempFormsFile);
+        setField("entitiesFile", tempEntitiesFile);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddFormsFromEntitiesMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+        primeFacesHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add forms from entities successfully")
+    void execute_ValidFiles_AddsForms() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession,
+                projectBuilder,
+                mavenProject))
+            .thenReturn(fullProject);
+
+        when(jakartaEeHelperMock.hasNotPrimeFacesDependency(fullProject, mockLog)).thenReturn(true);
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).addPrimeFacesDependency(mavenProject, mockLog);
+        verify(primeFacesHelperMock).addFormsFromEntities(fullProject,
+            mockLog,
+            tempFormsFile.toPath(),
+            tempEntitiesFile.toPath());
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when forms file does not exist")
+    void execute_MissingFormsFile_ThrowsMojoExecutionException() throws Exception {
+        File nonExistent = new File("non-existent-form-file.json");
+        setField("formsFile", nonExistent);
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("File not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/glassfish/AddGlassFishEmbeddedMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/glassfish/AddGlassFishEmbeddedMojoTest.java
@@ -1,0 +1,79 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.glassfish;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.GlassFishHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddGlassFishEmbeddedMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddGlassFishEmbeddedMojo mojo;
+
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<GlassFishHelper> glassFishHelperMockedStatic;
+
+    @Mock
+    private GlassFishHelper glassFishHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        glassFishHelperMockedStatic = mockStatic(GlassFishHelper.class);
+
+        glassFishHelperMockedStatic.when(GlassFishHelper::getInstance).thenReturn(glassFishHelperMock);
+
+        // Inject private fields that would normally be injected by Maven
+        java.lang.reflect.Field profileIdField = AddGlassFishEmbeddedMojo.class.getDeclaredField("profileId");
+        profileIdField.setAccessible(true);
+        profileIdField.set(mojo, "glassfish");
+
+        java.lang.reflect.Field portField = AddGlassFishEmbeddedMojo.class.getDeclaredField("port");
+        portField.setAccessible(true);
+        portField.set(mojo, 8080);
+
+        java.lang.reflect.Field contextRootField = AddGlassFishEmbeddedMojo.class.getDeclaredField("contextRoot");
+        contextRootField.setAccessible(true);
+        contextRootField.set(mojo, "my-app");
+    }
+
+    @AfterEach
+    void tearDown() {
+        pomUtilMockedStatic.close();
+        glassFishHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add GlassFish embedded plugin successfully")
+    void execute_ValidProject_AddsPlugin() throws Exception {
+        doNothing().when(glassFishHelperMock).addPlugin(mavenProject, mockLog, "glassfish", 8080, "my-app");
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(glassFishHelperMock).addPlugin(mavenProject, mockLog, "glassfish", 8080, "my-app");
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/jakartaee/AddValidationApiMojoTest.java
@@ -1,0 +1,119 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.jakartaee;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class AddValidationApiMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddValidationApiMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @BeforeEach
+    void setUp() {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add validation API when full project is resolved and version exists")
+    void execute_ValidProject_AddsDependency() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.of("10.0.0"));
+
+        doNothing().when(jakartaEeHelperMock).addJakartaValidationApiDependency(mavenProject, mockLog, "10.0.0");
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).addJakartaValidationApiDependency(mavenProject, mockLog, "10.0.0");
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when Jakarta EE version is missing")
+    void execute_MissingJakartaEeVersion_ThrowsMojoExecutionException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+        
+        verifyNoInteractions(jakartaEeHelperMock);
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoFailureException when project builder fails")
+    void execute_ProjectBuilderFails_ThrowsMojoFailureException() throws Exception {
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenThrow(new ProjectBuildingException("test", "Error building", new Exception()));
+
+        assertThrows(MojoFailureException.class, () -> mojo.execute());
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/payara/AddPayaraMicroMojoTest.java
@@ -1,0 +1,124 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.payara;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.PayaraMicroHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddPayaraMicroMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddPayaraMicroMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<PayaraMicroHelper> payaraMicroHelperMockedStatic;
+
+    @Mock
+    private PayaraMicroHelper payaraMicroHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        payaraMicroHelperMockedStatic = mockStatic(PayaraMicroHelper.class);
+
+        payaraMicroHelperMockedStatic.when(PayaraMicroHelper::getInstance).thenReturn(payaraMicroHelperMock);
+
+        java.lang.reflect.Field profileIdField = AddPayaraMicroMojo.class.getDeclaredField("profileId");
+        profileIdField.setAccessible(true);
+        profileIdField.set(mojo, "payaramicro");
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        payaraMicroHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add Payara Micro plugin successfully")
+    void execute_ValidProject_AddsPlugin() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.of("10.0.0"));
+
+        doNothing().when(payaraMicroHelperMock).addPlugin(mavenProject, mockLog, "payaramicro", "10.0.0");
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(payaraMicroHelperMock).addPlugin(mavenProject, mockLog, "payaramicro", "10.0.0");
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when Jakarta EE version is missing")
+    void execute_MissingJakartaEeVersion_ThrowsMojoExecutionException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+
+    @Test
+    @DisplayName("execute: should catch and log exception on project building failure")
+    void execute_ProjectBuilderFails_LogsError() throws Exception {
+        ProjectBuildingException buildException = new ProjectBuildingException("test", "Error building", new Exception());
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenThrow(buildException);
+
+        mojo.execute();
+
+        verify(mockLog).error(eq("Error building for project test"), eq(buildException));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
@@ -1,0 +1,119 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.persistence;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.PersistenceXmlHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.CoffeeBuilderUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import jakarta.json.Json;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddDataSourceMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddDataSourceMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<PersistenceXmlHelper> persistenceXmlHelperMockedStatic;
+    private MockedStatic<CoffeeBuilderUtil> coffeeBuilderUtilMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private PersistenceXmlHelper persistenceXmlHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        persistenceXmlHelperMockedStatic = mockStatic(PersistenceXmlHelper.class);
+        coffeeBuilderUtilMockedStatic = mockStatic(CoffeeBuilderUtil.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        persistenceXmlHelperMockedStatic.when(PersistenceXmlHelper::getInstance).thenReturn(persistenceXmlHelperMock);
+
+        setField("datasourceName", "myDS");
+        setField("url", "jdbc:h2:mem:test");
+        setField("declare", "web");
+        setField("persistenceUnitName", "myPU");
+        setField("mavenProject", mavenProject);
+        setField("mavenSession", mavenSession);
+        setField("projectBuilder", projectBuilder);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddAbstractPersistenceMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+        persistenceXmlHelperMockedStatic.close();
+        coffeeBuilderUtilMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add data source successfully")
+    void execute_ValidProject_AddsDataSource() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        var jdbcConfig = Json.createObjectBuilder().add("dataSourceClass", "org.h2.jdbcx.JdbcDataSource").build();
+        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration("jdbc:h2:mem:test"))
+                .thenReturn(Optional.of(jdbcConfig));
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(fullProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(persistenceXmlHelperMock).addDataSourceToPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"), eq("jdbc/myDS"));
+        verify(jakartaEeHelperMock).checkDataDependencies(eq(fullProject), eq(mockLog), eq(jdbcConfig));
+        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any());
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(fullProject, mockLog));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
@@ -104,7 +104,7 @@ class AddDataSourceMojoTest {
                 .thenReturn(fullProject);
 
         var jdbcConfig = Json.createObjectBuilder().add("dataSourceClass", "org.h2.jdbcx.JdbcDataSource").build();
-        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration("jdbc:h2:mem:test"))
+        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration(mockLog,"jdbc:h2:mem:test"))
                 .thenReturn(Optional.of(jdbcConfig));
 
         pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(fullProject, mockLog)).thenAnswer(inv -> null);

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddDataSourceMojoTest.java
@@ -113,7 +113,7 @@ class AddDataSourceMojoTest {
 
         verify(persistenceXmlHelperMock).addDataSourceToPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"), eq("jdbc/myDS"));
         verify(jakartaEeHelperMock).checkDataDependencies(eq(fullProject), eq(mockLog), eq(jdbcConfig));
-        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any());
+        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any(), any());
         pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(fullProject, mockLog));
     }
 }

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddEntitiesMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddEntitiesMojoTest.java
@@ -1,0 +1,110 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.persistence;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaPersistenceHelper;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddEntitiesMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddEntitiesMojo mojo;
+
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<JakartaPersistenceHelper> jakartaPersistenceHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private JakartaPersistenceHelper jakartaPersistenceHelperMock;
+
+    private File tempFile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        jakartaPersistenceHelperMockedStatic = mockStatic(JakartaPersistenceHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        jakartaPersistenceHelperMockedStatic.when(JakartaPersistenceHelper::getInstance).thenReturn(jakartaPersistenceHelperMock);
+
+        tempFile = File.createTempFile("entities", ".json");
+        tempFile.deleteOnExit();
+
+        java.lang.reflect.Field entitiesFileField = AddEntitiesMojo.class.getDeclaredField("entitiesFile");
+        entitiesFileField.setAccessible(true);
+        entitiesFileField.set(mojo, tempFile);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jakartaEeHelperMockedStatic.close();
+        jakartaPersistenceHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add entities successfully")
+    void execute_ValidFileAndProject_AddsEntities() throws Exception {
+        Path mockPersistenceXmlPath = Paths.get("src/main/resources/META-INF/persistence.xml");
+        when(jakartaEeHelperMock.getPersistenceXmlPath(mavenProject))
+                .thenReturn(Optional.of(mockPersistenceXmlPath));
+
+        mojo.execute();
+
+        verify(jakartaPersistenceHelperMock).addEntities(mavenProject, mockLog, tempFile.toPath(), mockPersistenceXmlPath);
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when entities file does not exist")
+    void execute_MissingEntitiesFile_ThrowsMojoExecutionException() throws Exception {
+        File nonExistent = new File("non-existent-file-12345.json");
+        java.lang.reflect.Field entitiesFileField = AddEntitiesMojo.class.getDeclaredField("entitiesFile");
+        entitiesFileField.setAccessible(true);
+        entitiesFileField.set(mojo, nonExistent);
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Error adding entities"));
+        verify(mockLog).error("Entities file not found: " + nonExistent.getAbsolutePath());
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when persistence.xml not found")
+    void execute_MissingPersistenceXml_ThrowsMojoExecutionException() throws Exception {
+        when(jakartaEeHelperMock.getPersistenceXmlPath(mavenProject))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Error adding entities"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddEntitiesMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddEntitiesMojoTest.java
@@ -57,7 +57,8 @@ class AddEntitiesMojoTest {
         jakartaPersistenceHelperMockedStatic = mockStatic(JakartaPersistenceHelper.class);
 
         jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
-        jakartaPersistenceHelperMockedStatic.when(JakartaPersistenceHelper::getInstance).thenReturn(jakartaPersistenceHelperMock);
+        jakartaPersistenceHelperMockedStatic.when(() -> JakartaPersistenceHelper.getInstance(mockLog))
+                .thenReturn(jakartaPersistenceHelperMock);
 
         tempFile = File.createTempFile("entities", ".json");
         tempFile.deleteOnExit();

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
@@ -1,0 +1,152 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.persistence;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.PersistenceXmlHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.CoffeeBuilderUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import jakarta.json.Json;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AddPersistenceMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private AddPersistenceMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<PersistenceXmlHelper> persistenceXmlHelperMockedStatic;
+    private MockedStatic<CoffeeBuilderUtil> coffeeBuilderUtilMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private PersistenceXmlHelper persistenceXmlHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        persistenceXmlHelperMockedStatic = mockStatic(PersistenceXmlHelper.class);
+        coffeeBuilderUtilMockedStatic = mockStatic(CoffeeBuilderUtil.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        persistenceXmlHelperMockedStatic.when(PersistenceXmlHelper::getInstance).thenReturn(persistenceXmlHelperMock);
+
+        setField("datasourceName", "myDS");
+        setField("url", "jdbc:h2:mem:test");
+        setField("declare", "web");
+        setField("persistenceUnitName", "myPU");
+        setField("mavenProject", mavenProject);
+        setField("mavenSession", mavenSession);
+        setField("projectBuilder", projectBuilder);
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = AddAbstractPersistenceMojo.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(mojo, value);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+        persistenceXmlHelperMockedStatic.close();
+        coffeeBuilderUtilMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add persistence configuration successfully")
+    void execute_ValidProject_AddsPersistence() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        var jdbcConfig = Json.createObjectBuilder().add("dataSourceClass", "org.h2.jdbcx.JdbcDataSource").build();
+        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration("jdbc:h2:mem:test"))
+                .thenReturn(Optional.of(jdbcConfig));
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.of("10.0.0"));
+
+        lenient().when(jakartaEeHelperMock.hasNotJakartaCdiDependency(fullProject, mockLog)).thenReturn(true);
+        lenient().when(jakartaEeHelperMock.hasNotJakartaPersistenceDependency(fullProject, mockLog)).thenReturn(true);
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(fullProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).createPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"));
+        verify(persistenceXmlHelperMock).addDataSourceToPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"), eq("jdbc/myDS"));
+        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any());
+        
+        verify(jakartaEeHelperMock).addJakartaCdiDependency(mavenProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addJakartaPersistenceDependency(fullProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addPersistenceClassProvider(mavenProject, mockLog);
+
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(fullProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw MojoExecutionException when Jakarta EE version missing")
+    void execute_MissingJakartaEeVersion_ThrowsException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        var jdbcConfig = Json.createObjectBuilder().add("dataSourceClass", "org.h2.jdbcx.JdbcDataSource").build();
+        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration("jdbc:h2:mem:test"))
+                .thenReturn(Optional.of(jdbcConfig));
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
@@ -109,7 +109,7 @@ class AddPersistenceMojoTest {
                 .thenReturn(fullProject);
 
         var jdbcConfig = Json.createObjectBuilder().add("dataSourceClass", "org.h2.jdbcx.JdbcDataSource").build();
-        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration("jdbc:h2:mem:test"))
+        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration(mockLog,"jdbc:h2:mem:test"))
                 .thenReturn(Optional.of(jdbcConfig));
 
         pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
@@ -141,7 +141,7 @@ class AddPersistenceMojoTest {
                 .thenReturn(fullProject);
 
         var jdbcConfig = Json.createObjectBuilder().add("dataSourceClass", "org.h2.jdbcx.JdbcDataSource").build();
-        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration("jdbc:h2:mem:test"))
+        coffeeBuilderUtilMockedStatic.when(() -> CoffeeBuilderUtil.getJdbcConfiguration(mockLog, "jdbc:h2:mem:test"))
                 .thenReturn(Optional.of(jdbcConfig));
 
         pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/persistence/AddPersistenceMojoTest.java
@@ -82,6 +82,7 @@ class AddPersistenceMojoTest {
         setField("mavenProject", mavenProject);
         setField("mavenSession", mavenSession);
         setField("projectBuilder", projectBuilder);
+        setField("profile", "default");
     }
 
     private void setField(String fieldName, Object value) throws Exception {
@@ -123,8 +124,8 @@ class AddPersistenceMojoTest {
 
         verify(jakartaEeHelperMock).createPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"));
         verify(persistenceXmlHelperMock).addDataSourceToPersistenceXml(eq(fullProject), eq(mockLog), eq("myPU"), eq("jdbc/myDS"));
-        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any());
-        
+        verify(jakartaEeHelperMock).addDataSource(eq(fullProject), eq(mockLog), eq("web"), any(), any());
+
         verify(jakartaEeHelperMock).addJakartaCdiDependency(mavenProject, mockLog, "10.0.0");
         verify(jakartaEeHelperMock).addJakartaPersistenceDependency(fullProject, mockLog, "10.0.0");
         verify(jakartaEeHelperMock).addPersistenceClassProvider(mavenProject, mockLog);

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojoTest.java
@@ -1,0 +1,128 @@
+package com.apuntesdejava.jakartacoffeebuilder.mojo.rest;
+
+import com.apuntesdejava.jakartacoffeebuilder.helper.JakartaEeHelper;
+import com.apuntesdejava.jakartacoffeebuilder.helper.OpenApiGeneratorHelper;
+import com.apuntesdejava.jakartacoffeebuilder.util.MavenProjectUtil;
+import com.apuntesdejava.jakartacoffeebuilder.util.PomUtil;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CreateOpenApiMojoTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private MavenSession mavenSession;
+
+    @Mock
+    private ProjectBuilder projectBuilder;
+
+    @Mock
+    private Log mockLog;
+
+    @InjectMocks
+    private CreateOpenApiMojo mojo;
+
+    private MockedStatic<MavenProjectUtil> mavenProjectUtilMockedStatic;
+    private MockedStatic<PomUtil> pomUtilMockedStatic;
+    private MockedStatic<JakartaEeHelper> jakartaEeHelperMockedStatic;
+    private MockedStatic<OpenApiGeneratorHelper> openApiGeneratorHelperMockedStatic;
+
+    @Mock
+    private JakartaEeHelper jakartaEeHelperMock;
+
+    @Mock
+    private OpenApiGeneratorHelper openApiGeneratorHelperMock;
+
+    private File tempFile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mojo.setLog(mockLog);
+
+        mavenProjectUtilMockedStatic = mockStatic(MavenProjectUtil.class);
+        pomUtilMockedStatic = mockStatic(PomUtil.class);
+        jakartaEeHelperMockedStatic = mockStatic(JakartaEeHelper.class);
+        openApiGeneratorHelperMockedStatic = mockStatic(OpenApiGeneratorHelper.class);
+
+        jakartaEeHelperMockedStatic.when(JakartaEeHelper::getInstance).thenReturn(jakartaEeHelperMock);
+        openApiGeneratorHelperMockedStatic.when(OpenApiGeneratorHelper::getInstance).thenReturn(openApiGeneratorHelperMock);
+
+        tempFile = File.createTempFile("openapi", ".yml");
+        tempFile.deleteOnExit();
+
+        java.lang.reflect.Field openApiFileServerField = CreateOpenApiMojo.class.getDeclaredField("openApiFileServer");
+        openApiFileServerField.setAccessible(true);
+        openApiFileServerField.set(mojo, tempFile);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenProjectUtilMockedStatic.close();
+        pomUtilMockedStatic.close();
+        jakartaEeHelperMockedStatic.close();
+        openApiGeneratorHelperMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("execute: should add OpenAPI configurations successfully")
+    void execute_ValidProject_AddsConfigurations() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.of("10.0.0"));
+
+        pomUtilMockedStatic.when(() -> PomUtil.saveMavenProject(mavenProject, mockLog)).thenAnswer(inv -> null);
+
+        mojo.execute();
+
+        verify(jakartaEeHelperMock).addJacksonDependency(mavenProject, mockLog);
+        verify(jakartaEeHelperMock).addMicroprofileOpenApiApiDependency(mavenProject, mockLog);
+        verify(jakartaEeHelperMock).addJakartaValidationApiDependency(mavenProject, mockLog, "10.0.0");
+        verify(jakartaEeHelperMock).addHelperGenerateSource(mavenProject, mockLog);
+        
+        verify(openApiGeneratorHelperMock).processServer(mavenProject, tempFile, mockLog);
+
+        pomUtilMockedStatic.verify(() -> PomUtil.saveMavenProject(mavenProject, mockLog));
+    }
+
+    @Test
+    @DisplayName("execute: should throw exception when Jakarta EE version is missing")
+    void execute_MissingJakartaEeVersion_ThrowsException() throws Exception {
+        MavenProject fullProject = mock(MavenProject.class);
+        mavenProjectUtilMockedStatic.when(() -> MavenProjectUtil.getFullProject(mavenSession, projectBuilder, mavenProject))
+                .thenReturn(fullProject);
+
+        pomUtilMockedStatic.when(() -> PomUtil.getJakartaEeCurrentVersion(fullProject, mockLog))
+                .thenReturn(Optional.empty());
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+        assertTrue(exception.getMessage().contains("Jakarta EE dependency not found"));
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojoTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/mojo/rest/CreateOpenApiMojoTest.java
@@ -102,7 +102,6 @@ class CreateOpenApiMojoTest {
 
         mojo.execute();
 
-        verify(jakartaEeHelperMock).addJacksonDependency(mavenProject, mockLog);
         verify(jakartaEeHelperMock).addMicroprofileOpenApiApiDependency(mavenProject, mockLog);
         verify(jakartaEeHelperMock).addJakartaValidationApiDependency(mavenProject, mockLog, "10.0.0");
         verify(jakartaEeHelperMock).addHelperGenerateSource(mavenProject, mockLog);

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/DataSourceUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/DataSourceUtilTest.java
@@ -1,0 +1,72 @@
+package com.apuntesdejava.jakartacoffeebuilder.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_ASADMIN;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_CLASS;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DATASOURCE_DECLARE_WEB;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DataSourceUtilTest {
+
+    @Nested
+    @DisplayName("getPrefix")
+    class GetPrefix {
+
+        @Test
+        @DisplayName("should return java:global/jdbc/ for web.xml declaration")
+        void returnGlobalPrefixForWeb() {
+            assertEquals("java:global/jdbc/", DataSourceUtil.getPrefix(DATASOURCE_DECLARE_WEB));
+        }
+
+        @Test
+        @DisplayName("should return java:app/jdbc/ for class declaration")
+        void returnAppPrefixForClass() {
+            assertEquals("java:app/jdbc/", DataSourceUtil.getPrefix(DATASOURCE_DECLARE_CLASS));
+        }
+
+        @Test
+        @DisplayName("should return jdbc/ for unknown declaration")
+        void returnJdbcPrefixForUnknown() {
+            assertEquals("jdbc/", DataSourceUtil.getPrefix("unknown"));
+        }
+
+        @Test
+        @DisplayName("should return jdbc/ for asadmin declaration")
+        void returnJdbcPrefixForAsadmin() {
+            assertEquals("jdbc/", DataSourceUtil.getPrefix(DATASOURCE_DECLARE_ASADMIN));
+        }
+    }
+
+    @Nested
+    @DisplayName("validateDataSourceName")
+    class ValidateDataSourceName {
+
+        @Test
+        @DisplayName("should return fully qualified name for valid datasource name")
+        void returnsFullyQualifiedName() {
+            String result = DataSourceUtil.validateDataSourceName(DATASOURCE_DECLARE_WEB, "myDataSource");
+            assertEquals("java:global/jdbc/myDataSource", result);
+        }
+
+        @Test
+        @DisplayName("should accept name starting with letter and containing digits/underscores")
+        void acceptsValidNameWithDigitsAndUnderscores() {
+            String result = DataSourceUtil.validateDataSourceName(DATASOURCE_DECLARE_CLASS, "db_01_main");
+            assertEquals("java:app/jdbc/db_01_main", result);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"1invalid", "my-ds", "my ds", "ds@name", ""})
+        @DisplayName("should throw IllegalArgumentException for invalid names")
+        void throwsForInvalidName(String invalidName) {
+            assertThrows(IllegalArgumentException.class,
+                () -> DataSourceUtil.validateDataSourceName(DATASOURCE_DECLARE_WEB, invalidName));
+        }
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtilTest.java
@@ -1,11 +1,17 @@
 package com.apuntesdejava.jakartacoffeebuilder.util;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.function.Function;
 
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.DEV_BASE_URL;
+import static com.apuntesdejava.jakartacoffeebuilder.util.Constants.PRD_BASE_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -26,5 +32,54 @@ public class HttpUtilTest {
 
         // Verify the result
         assertEquals("mocked response", result);
+    }
+
+    @Nested
+    @DisplayName("getUrl")
+    class GetUrl {
+
+        @AfterEach
+        void cleanUpSystemProperty() {
+            System.clearProperty("devel");
+        }
+
+        @Test
+        @DisplayName("should use PRD base URL when devel is false")
+        void usesPrdBaseUrlByDefault() {
+            System.setProperty("devel", "false");
+            String result = HttpUtil.getUrl("/dependencies.json");
+            assertTrue(result.startsWith(PRD_BASE_URL));
+            assertEquals(PRD_BASE_URL + "/dependencies.json", result);
+        }
+
+        @Test
+        @DisplayName("should use DEV base URL when devel is true")
+        void usesDevBaseUrlWhenDevelTrue() {
+            System.setProperty("devel", "true");
+            String result = HttpUtil.getUrl("/dependencies.json");
+            assertTrue(result.startsWith(DEV_BASE_URL));
+            assertEquals(DEV_BASE_URL + "/dependencies.json", result);
+        }
+
+        @Test
+        @DisplayName("should use PRD base URL when devel property is not set")
+        void usesPrdBaseUrlWhenPropertyNotSet() {
+            System.clearProperty("devel");
+            String result = HttpUtil.getUrl("/servers.json");
+            assertEquals(PRD_BASE_URL + "/servers.json", result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Parameter record")
+    class ParameterRecord {
+
+        @Test
+        @DisplayName("should store name and value")
+        void storesNameAndValue() {
+            HttpUtil.Parameter param = new HttpUtil.Parameter("key", "value");
+            assertEquals("key", param.name());
+            assertEquals("value", param.value());
+        }
     }
 }

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/HttpUtilTest.java
@@ -1,9 +1,13 @@
 package com.apuntesdejava.jakartacoffeebuilder.util;
 
+import org.apache.maven.plugin.logging.Log;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -16,7 +20,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class HttpUtilTest {
+    @Mock
+    private Log mockLog;
 
     @Test
     public void testGetContent() throws IOException {
@@ -28,7 +35,7 @@ public class HttpUtilTest {
         HttpUtil.Parameter param = new HttpUtil.Parameter("key", "value");
 
         // Call the method
-        String result = HttpUtil.getContent("http://example.com", converter, param);
+        String result = HttpUtil.getContent(mockLog, "http://example.com", converter, param);
 
         // Verify the result
         assertEquals("mocked response", result);

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/MavenProjectUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/MavenProjectUtilTest.java
@@ -1,0 +1,228 @@
+package com.apuntesdejava.jakartacoffeebuilder.util;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MavenProjectUtilTest {
+
+    @Mock
+    private MavenProject mockProject;
+
+    @Nested
+    @DisplayName("getProjectPackage")
+    class GetProjectPackage {
+
+        @Test
+        @DisplayName("should derive package from groupId and artifactId")
+        void derivesPackageFromCoordinates() {
+            when(mockProject.getGroupId()).thenReturn("com.example");
+            when(mockProject.getArtifactId()).thenReturn("my-app");
+
+            String result = MavenProjectUtil.getProjectPackage(mockProject);
+
+            assertEquals("com.example.my.app", result);
+        }
+
+        @Test
+        @DisplayName("should replace non-alphanumeric characters with dots")
+        void replacesSpecialChars() {
+            when(mockProject.getGroupId()).thenReturn("com.apuntesdejava");
+            when(mockProject.getArtifactId()).thenReturn("jakarta-coffee-builder");
+
+            String result = MavenProjectUtil.getProjectPackage(mockProject);
+
+            assertEquals("com.apuntesdejava.jakarta.coffee.builder", result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Layer package methods")
+    class LayerPackages {
+
+        @BeforeEach
+        void setUp() {
+            when(mockProject.getGroupId()).thenReturn("com.example");
+            when(mockProject.getArtifactId()).thenReturn("myapp");
+        }
+
+        @Test
+        @DisplayName("getEntityPackage should append infrastructure.entity")
+        void entityPackage() {
+            assertEquals("com.example.myapp.infrastructure.entity",
+                MavenProjectUtil.getEntityPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getModelPackage should append domain.model")
+        void modelPackage() {
+            assertEquals("com.example.myapp.domain.model",
+                MavenProjectUtil.getModelPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getMapperPackage should append infrastructure.mapper")
+        void mapperPackage() {
+            assertEquals("com.example.myapp.infrastructure.mapper",
+                MavenProjectUtil.getMapperPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getServicePackage should append infrastructure.domain")
+        void servicePackage() {
+            assertEquals("com.example.myapp.infrastructure.domain",
+                MavenProjectUtil.getServicePackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getRepositoryPackage should append infrastructure.repository")
+        void repositoryPackage() {
+            assertEquals("com.example.myapp.infrastructure.repository",
+                MavenProjectUtil.getRepositoryPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getProviderPackage should append infrastructure.provider")
+        void providerPackage() {
+            assertEquals("com.example.myapp.infrastructure.provider",
+                MavenProjectUtil.getProviderPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getEnumsPackage should append enums")
+        void enumsPackage() {
+            assertEquals("com.example.myapp.enums",
+                MavenProjectUtil.getEnumsPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getFacesPackage should append app.faces")
+        void facesPackage() {
+            assertEquals("com.example.myapp.app.faces",
+                MavenProjectUtil.getFacesPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getApiResourcesPackage should append app.resources")
+        void apiResourcesPackage() {
+            assertEquals("com.example.myapp.app.resources",
+                MavenProjectUtil.getApiResourcesPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getDomainModelPackage should append domain.model")
+        void domainModelPackage() {
+            assertEquals("com.example.myapp.domain.model",
+                MavenProjectUtil.getDomainModelPackage(mockProject));
+        }
+
+        @Test
+        @DisplayName("getModelRepositoryPackage should append domain.repository")
+        void modelRepositoryPackage() {
+            assertEquals("com.example.myapp.domain.repository",
+                MavenProjectUtil.getModelRepositoryPackage(mockProject));
+        }
+    }
+
+    @Nested
+    @DisplayName("getProfile")
+    class GetProfile {
+
+        @Test
+        @DisplayName("should return existing profile when found")
+        void returnsExistingProfile() {
+            var model = new Model();
+            var existingProfile = new Profile();
+            existingProfile.setId("test-profile");
+            model.addProfile(existingProfile);
+            when(mockProject.getOriginalModel()).thenReturn(model);
+
+            Profile result = MavenProjectUtil.getProfile(mockProject, "test-profile");
+
+            assertSame(existingProfile, result);
+        }
+
+        @Test
+        @DisplayName("should create and return new profile when not found")
+        void createsNewProfile() {
+            var model = new Model();
+            when(mockProject.getOriginalModel()).thenReturn(model);
+
+            Profile result = MavenProjectUtil.getProfile(mockProject, "new-profile");
+
+            assertEquals("new-profile", result.getId());
+            assertEquals(1, model.getProfiles().size());
+        }
+    }
+
+    @Nested
+    @DisplayName("getParent")
+    class GetParent {
+
+        @Test
+        @DisplayName("should return parent path of POM file")
+        void returnsParentPath() {
+            File pomFile = new File("/projects/my-app/pom.xml");
+            when(mockProject.getFile()).thenReturn(pomFile);
+
+            Path result = MavenProjectUtil.getParent(mockProject);
+
+            assertEquals(pomFile.toPath().getParent(), result);
+        }
+    }
+
+    @Nested
+    @DisplayName("getBuild")
+    class GetBuild {
+
+        @Test
+        @DisplayName("should return existing build from profile")
+        void returnsExistingBuild() {
+            var model = new Model();
+            var profile = new Profile();
+            profile.setId("some-profile");
+            var build = new Build();
+            build.setPlugins(new ArrayList<>());
+            profile.setBuild(build);
+            model.addProfile(profile);
+            when(mockProject.getOriginalModel()).thenReturn(model);
+
+            var result = MavenProjectUtil.getBuild(mockProject, "some-profile");
+
+            assertSame(build, result);
+        }
+
+        @Test
+        @DisplayName("should create new build when profile has none")
+        void createsNewBuild() {
+            var model = new Model();
+            var profile = new Profile();
+            profile.setId("empty-profile");
+            model.addProfile(profile);
+            when(mockProject.getOriginalModel()).thenReturn(model);
+
+            var result = MavenProjectUtil.getBuild(mockProject, "empty-profile");
+
+            assertNotNull(result);
+            assertNotNull(result.getPlugins());
+        }
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/StringsUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/StringsUtilTest.java
@@ -1,0 +1,208 @@
+package com.apuntesdejava.jakartacoffeebuilder.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StringsUtilTest {
+
+    @Nested
+    @DisplayName("removeCharacterRoot")
+    class RemoveCharacterRoot {
+
+        @Test
+        @DisplayName("should remove leading slash")
+        void removesLeadingSlash() {
+            assertEquals("path/to/file", StringsUtil.removeCharacterRoot("/path/to/file"));
+        }
+
+        @Test
+        @DisplayName("should return path unchanged when no leading slash")
+        void returnsUnchangedWhenNoLeadingSlash() {
+            assertEquals("path/to/file", StringsUtil.removeCharacterRoot("path/to/file"));
+        }
+
+        @Test
+        @DisplayName("should handle single slash")
+        void handlesSingleSlash() {
+            assertEquals("", StringsUtil.removeCharacterRoot("/"));
+        }
+
+        @Test
+        @DisplayName("should handle empty string")
+        void handlesEmptyString() {
+            assertEquals("", StringsUtil.removeCharacterRoot(""));
+        }
+    }
+
+    @Nested
+    @DisplayName("toPascalCase")
+    class ToPascalCase {
+
+        @ParameterizedTest
+        @CsvSource({
+            "hello-world, HelloWorld",
+            "my_class_name, MyClassName",
+            "simple, Simple",
+            "already-Pascal, AlreadyPascal",
+            "one.two.three, OneTwoThree"
+        })
+        @DisplayName("should convert delimited strings to PascalCase")
+        void convertsToPascalCase(String input, String expected) {
+            assertEquals(expected, StringsUtil.toPascalCase(input));
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   ", "  \t "})
+        @DisplayName("should return empty for null, blank, or empty input")
+        void returnsEmptyForBlankInput(String input) {
+            assertEquals("", StringsUtil.toPascalCase(input));
+        }
+
+        @Test
+        @DisplayName("should handle string with only special characters")
+        void handlesOnlySpecialChars() {
+            assertEquals("", StringsUtil.toPascalCase("---"));
+        }
+    }
+
+    @Nested
+    @DisplayName("camelCaseToParamCase")
+    class CamelCaseToParamCase {
+
+        @ParameterizedTest
+        @CsvSource({
+            "camelCase, camel-case",
+            "myVariableName, my-variable-name",
+            "simple, simple",
+            "HTMLParser, html-parser"
+        })
+        @DisplayName("should convert camelCase to param-case")
+        void convertsCorrectly(String input, String expected) {
+            assertEquals(expected, StringsUtil.camelCaseToParamCase(input));
+        }
+    }
+
+    @Nested
+    @DisplayName("containsIgnoreCase")
+    class ContainsIgnoreCase {
+
+        @Test
+        @DisplayName("should return true when set contains value (same case)")
+        void returnsTrueForSameCase() {
+            assertTrue(StringsUtil.containsIgnoreCase(Set.of("Hello", "World"), "Hello"));
+        }
+
+        @Test
+        @DisplayName("should return true when set contains value (different case)")
+        void returnsTrueForDifferentCase() {
+            assertTrue(StringsUtil.containsIgnoreCase(Set.of("Hello", "World"), "hello"));
+        }
+
+        @Test
+        @DisplayName("should return false when set does not contain value")
+        void returnsFalseWhenNotFound() {
+            assertFalse(StringsUtil.containsIgnoreCase(Set.of("Hello", "World"), "Foo"));
+        }
+    }
+
+    @Nested
+    @DisplayName("containsAnyIgnoreCase")
+    class ContainsAnyIgnoreCase {
+
+        @Test
+        @DisplayName("should return true when any element matches")
+        void returnsTrueWhenAnyMatches() {
+            assertTrue(StringsUtil.containsAnyIgnoreCase(
+                Set.of("Hello", "World"),
+                Set.of("world", "foo")));
+        }
+
+        @Test
+        @DisplayName("should return false when no element matches")
+        void returnsFalseWhenNoneMatches() {
+            assertFalse(StringsUtil.containsAnyIgnoreCase(
+                Set.of("Hello", "World"),
+                Set.of("foo", "bar")));
+        }
+    }
+
+    @Nested
+    @DisplayName("findIgnoreCase(Set, Set)")
+    class FindIgnoreCaseSet {
+
+        @Test
+        @DisplayName("should find matching entries ignoring case")
+        void findsMatchingEntries() {
+            Collection<String> result = StringsUtil.findIgnoreCase(
+                Set.of("Column", "JoinColumn", "ManyToOne"),
+                Set.of("column", "manytoone"));
+            assertEquals(2, result.size());
+            assertTrue(result.contains("Column"));
+            assertTrue(result.contains("ManyToOne"));
+        }
+
+        @Test
+        @DisplayName("should return empty when no match found")
+        void returnsEmptyWhenNoMatch() {
+            Collection<String> result = StringsUtil.findIgnoreCase(
+                Set.of("Column", "JoinColumn"),
+                Set.of("foo", "bar"));
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("findIgnoreCase(Set, String)")
+    class FindIgnoreCaseString {
+
+        @Test
+        @DisplayName("should return matching string ignoring case")
+        void returnsMatchingString() {
+            String result = StringsUtil.findIgnoreCase(Set.of("Column", "JoinColumn"), "column");
+            assertEquals("Column", result);
+        }
+
+        @Test
+        @DisplayName("should return null when no match found")
+        void returnsNullWhenNotFound() {
+            assertNull(StringsUtil.findIgnoreCase(Set.of("Column", "JoinColumn"), "foo"));
+        }
+    }
+
+    @Nested
+    @DisplayName("findIgnoreCaseOptional")
+    class FindIgnoreCaseOptional {
+
+        @Test
+        @DisplayName("should return Optional with value when found")
+        void returnsOptionalWithValue() {
+            Optional<String> result = StringsUtil.findIgnoreCaseOptional(
+                Set.of("Column", "JoinColumn"), "joincolumn");
+            assertTrue(result.isPresent());
+            assertEquals("JoinColumn", result.get());
+        }
+
+        @Test
+        @DisplayName("should return empty Optional when not found")
+        void returnsEmptyOptional() {
+            Optional<String> result = StringsUtil.findIgnoreCaseOptional(
+                Set.of("Column", "JoinColumn"), "foo");
+            assertTrue(result.isEmpty());
+        }
+    }
+}

--- a/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/XmlUtilTest.java
+++ b/src/test/java/com/apuntesdejava/jakartacoffeebuilder/util/XmlUtilTest.java
@@ -1,4 +1,401 @@
 package com.apuntesdejava.jakartacoffeebuilder.util;
 
-public class XmlUtilTest {
+import org.apache.maven.plugin.logging.Log;
+import org.dom4j.Document;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.dom4j.Namespace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class XmlUtilTest {
+
+    private XmlUtil xmlUtil;
+    private Log mockLog;
+
+    @BeforeEach
+    void setUp() {
+        xmlUtil = XmlUtil.getInstance();
+        mockLog = mock(Log.class);
+    }
+
+    @Test
+    @DisplayName("getInstance: should return the same singleton instance")
+    void instanceIsSingleton() {
+        assertSame(XmlUtil.getInstance(), XmlUtil.getInstance());
+    }
+
+    @Nested
+    @DisplayName("addElement(parent, tagName, content)")
+    class AddElementWithContent {
+
+        @Test
+        @DisplayName("should add child element with text content")
+        void addsChildWithText() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+
+            xmlUtil.addElement(root, "child", "hello");
+
+            Element child = root.element("child");
+            assertNotNull(child);
+            assertEquals("hello", child.getText());
+        }
+    }
+
+    @Nested
+    @DisplayName("addElement(parent, tagName)")
+    class AddElementSimple {
+
+        @Test
+        @DisplayName("should add empty child element")
+        void addsEmptyChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+
+            Element result = xmlUtil.addElement(root, "child");
+
+            assertNotNull(result);
+            assertEquals("child", result.getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("addElement(parent, tagName, attributes)")
+    class AddElementWithAttributes {
+
+        @Test
+        @DisplayName("should add element with attributes")
+        void addsElementWithAttributes() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Map<String, String> attrs = new LinkedHashMap<>();
+            attrs.put("name", "test");
+            attrs.put("value", "123");
+
+            Element result = xmlUtil.addElement(root, "param", attrs);
+
+            // When element is new, result is the new element
+            Element param = root.element("param");
+            assertNotNull(param);
+            assertEquals("test", param.attributeValue("name"));
+            assertEquals("123", param.attributeValue("value"));
+        }
+
+        @Test
+        @DisplayName("should not add duplicate element with same attributes")
+        void skipsDuplicateElement() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Map<String, String> attrs = new LinkedHashMap<>();
+            attrs.put("name", "test");
+
+            xmlUtil.addElement(root, "param", attrs);
+            xmlUtil.addElement(root, "param", attrs); // duplicate
+
+            assertEquals(1, root.elements("param").size());
+        }
+    }
+
+    @Nested
+    @DisplayName("addElement(parent, tagName, namespace)")
+    class AddElementWithNamespace {
+
+        @Test
+        @DisplayName("should add element with namespace")
+        void addsElementWithNamespace() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Namespace ns = new Namespace("ns", "http://example.com/ns");
+
+            Element result = xmlUtil.addElement(root, "child", ns);
+
+            assertNotNull(result);
+            assertEquals("child", result.getName());
+            assertEquals("http://example.com/ns", result.getNamespaceURI());
+        }
+    }
+
+    @Nested
+    @DisplayName("findElements")
+    class FindElements {
+
+        @Test
+        @DisplayName("should find elements by XPath expression")
+        void findsElementsByXpath() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            root.addElement("item").setText("a");
+            root.addElement("item").setText("b");
+
+            Stream<Element> result = xmlUtil.findElements(doc, "//item");
+
+            assertEquals(2, result.count());
+        }
+
+        @Test
+        @DisplayName("should return empty stream when no elements match")
+        void returnsEmptyForNoMatch() {
+            Document doc = DocumentHelper.createDocument();
+            doc.addElement("root");
+
+            Stream<Element> result = xmlUtil.findElements(doc, "//nonexistent");
+
+            assertEquals(0, result.count());
+        }
+
+        @Test
+        @DisplayName("should throw NullPointerException for null document")
+        void throwsForNullDocument() {
+            assertThrows(NullPointerException.class,
+                () -> xmlUtil.findElements(null, "//test", Map.of()));
+        }
+    }
+
+    @Nested
+    @DisplayName("getElement")
+    class GetElement {
+
+        @Test
+        @DisplayName("should return existing child element")
+        void returnsExistingChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Element existing = root.addElement("child");
+            existing.setText("value");
+
+            var result = xmlUtil.getElement(root, "child");
+
+            assertTrue(result.isPresent());
+            assertEquals("value", result.get().getText());
+        }
+
+        @Test
+        @DisplayName("should create and return new element when not found")
+        void createsNewElement() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+
+            var result = xmlUtil.getElement(root, "newChild");
+
+            assertTrue(result.isPresent());
+            assertEquals("newChild", result.get().getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("getElement(parent, name, namespace)")
+    class GetElementWithNamespace {
+
+        @Test
+        @DisplayName("should return existing element with namespace")
+        void returnsExistingNamespacedElement() {
+            Document doc = DocumentHelper.createDocument();
+            Namespace ns = new Namespace("ns", "http://example.com");
+            Element root = doc.addElement("root");
+            root.addElement(org.dom4j.QName.get("child", ns)).setText("found");
+
+            var result = xmlUtil.getElement(root, "child", ns);
+
+            assertTrue(result.isPresent());
+            assertEquals("found", result.get().getText());
+        }
+
+        @Test
+        @DisplayName("should create new namespaced element when not found")
+        void createsNewNamespacedElement() {
+            Document doc = DocumentHelper.createDocument();
+            Namespace ns = new Namespace("ns", "http://example.com");
+            Element root = doc.addElement("root");
+
+            var result = xmlUtil.getElement(root, "newChild", ns);
+
+            assertTrue(result.isPresent());
+            assertEquals("newChild", result.get().getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("removeElement")
+    class RemoveElement {
+
+        @Test
+        @DisplayName("should remove existing child element")
+        void removesChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            root.addElement("toRemove");
+
+            xmlUtil.removeElement(root, "toRemove");
+
+            assertNull(root.element("toRemove"));
+        }
+
+        @Test
+        @DisplayName("should do nothing when element to remove does not exist")
+        void doesNothingWhenNotFound() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+
+            assertDoesNotThrow(() -> xmlUtil.removeElement(root, "nonexistent"));
+        }
+    }
+
+    @Nested
+    @DisplayName("removeElement(element, tagName, namespace)")
+    class RemoveElementWithNamespace {
+
+        @Test
+        @DisplayName("should remove namespaced child element")
+        void removesNamespacedChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            Namespace ns = new Namespace("ns", "http://example.com");
+            root.addElement(org.dom4j.QName.get("child", ns));
+
+            xmlUtil.removeElement(root, "child", ns);
+
+            assertNull(root.element(org.dom4j.QName.get("child", ns)));
+        }
+    }
+
+    @Nested
+    @DisplayName("addElementAsFirstChild")
+    class AddElementAsFirstChild {
+
+        @Test
+        @DisplayName("should add element as first child")
+        void addsAsFirstChild() {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            root.addElement("existing");
+
+            Element result = xmlUtil.addElementAsFirstChild(root, "first", "value");
+
+            assertEquals("first", result.getName());
+            assertEquals("value", result.getText());
+            // Verify it's the first content element
+            Element firstElement = (Element) root.content().getFirst();
+            assertEquals("first", firstElement.getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("saveDocument")
+    class SaveDocument {
+
+        @Test
+        @DisplayName("should save document to file")
+        void savesDocumentToFile(@TempDir Path tempDir) throws IOException {
+            Document doc = DocumentHelper.createDocument();
+            Element root = doc.addElement("root");
+            root.addElement("child").setText("value");
+
+            Path xmlFile = tempDir.resolve("test.xml");
+            xmlUtil.saveDocument(doc, mockLog, xmlFile);
+
+            assertTrue(Files.exists(xmlFile));
+            String content = Files.readString(xmlFile);
+            assertTrue(content.contains("<root>"));
+            assertTrue(content.contains("<child>value</child>"));
+        }
+
+        @Test
+        @DisplayName("should handle null document gracefully")
+        void handlesNullDocument(@TempDir Path tempDir) {
+            Path xmlFile = tempDir.resolve("test.xml");
+            assertDoesNotThrow(() -> xmlUtil.saveDocument(null, mockLog, xmlFile));
+            assertFalse(Files.exists(xmlFile));
+        }
+    }
+
+    @Nested
+    @DisplayName("getDocument")
+    class GetDocument {
+
+        @Test
+        @DisplayName("should read existing XML file")
+        void readsExistingFile(@TempDir Path tempDir) throws IOException {
+            Path xmlFile = tempDir.resolve("existing.xml");
+            Files.writeString(xmlFile, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root><child>test</child></root>");
+
+            var result = xmlUtil.getDocument(mockLog, xmlFile);
+
+            assertTrue(result.isPresent());
+            assertNotNull(result.get().getRootElement());
+            assertEquals("root", result.get().getRootElement().getName());
+        }
+
+        @Test
+        @DisplayName("should return empty Optional for non-existing file")
+        void returnsEmptyForMissingFile(@TempDir Path tempDir) {
+            Path nonExistingFile = tempDir.resolve("missing.xml");
+
+            var result = xmlUtil.getDocument(mockLog, nonExistingFile);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("should create new document with postCreate when file does not exist")
+        void createsNewDocumentWithPostCreate(@TempDir Path tempDir) {
+            Path newFile = tempDir.resolve("subdir/new.xml");
+
+            var result = xmlUtil.getDocument(mockLog, newFile,
+                doc -> doc.addElement("newRoot"));
+
+            assertTrue(result.isPresent());
+            assertEquals("newRoot", result.get().getRootElement().getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("addElement(document, log, parentNode, nodeName, postCreate)")
+    class AddElementToDocument {
+
+        @Test
+        @DisplayName("should add element to document node found by XPath")
+        void addsElementToDocumentNode() {
+            Document doc = DocumentHelper.createDocument();
+            doc.addElement("root");
+
+            Element result = xmlUtil.addElement(doc, mockLog, "//root", "child",
+                elem -> elem.setText("created"));
+
+            assertNotNull(result);
+            assertEquals("child", result.getName());
+            assertEquals("created", result.getText());
+        }
+
+        @Test
+        @DisplayName("should return null when parent node not found")
+        void returnsNullWhenParentNotFound() {
+            Document doc = DocumentHelper.createDocument();
+            doc.addElement("root");
+
+            Element result = xmlUtil.addElement(doc, mockLog, "//nonexistent", "child", null);
+
+            assertNull(result);
+        }
+    }
 }


### PR DESCRIPTION
 ## Overview

This pull request promotes the current `develop` branch into `main` and documents the accumulated work for the Jakarta Coffee Builder Maven plugin release line. The branch contains 11 commits on top of the shared history with `main`, including the version bump to `0.0.6`, build and dependency updates, datasource generation improvements, OpenAPI template additions, utility refactors, documentation cleanup, and a broad expansion of automated tests.

The intent of this PR is not only to merge the code, but also to provide a traceable summary of what changed so the release can be reviewed and followed up with clear context.

## Build and Release Preparation

The Maven project version is updated to `0.0.6` and the build setup is refreshed. This includes updates in `pom.xml` for plugin and dependency management, the addition of Maven Wrapper files, and wrapper properties so the project can be built consistently without requiring a preinstalled Maven version.

The build configuration also includes dependency and plugin updates around Jackson, Payara Micro, Maven Plugin tooling, Surefire, JaCoCo, and related project infrastructure. These changes are meant to stabilize the local and CI build path while keeping the plugin aligned with newer dependency versions.

## Datasource and Payara Improvements

Datasource generation has been extended with support for `asadmin`-based declarations. A new `DataSourceAsAdminCreator` implementation was added and the datasource creator factory was adjusted to select the correct datasource strategy. The datasource flow now has improved handling for server/profile specific behavior, including better command-line option handling for Payara-related configurations.

Related helper classes were refactored so datasource, persistence, Jakarta EE, GlassFish, Payara Micro, and XML generation logic can share cleaner conventions and produce more predictable project modifications.

## OpenAPI and Generated Code Templates

OpenAPI generation now includes custom templates for POJOs and enum outer classes. These templates give the plugin more control over generated model structure and naming behavior, which should make generated code easier to integrate with the rest of the Jakarta Coffee Builder conventions.

The mapper FreeMarker template was also adjusted as part of this cleanup.

## Helper and Utility Refactors

Several helper and utility classes were refined, including JSON, HTTP, POM, XML, web.xml, architecture, persistence, class definition, and general Coffee Builder utilities. The changes reduce repeated logic, improve JSON value handling, improve HTTP request execution, and make generated project updates more consistent.

The persistence-related mojos were also updated, especially the abstract persistence flow, to better coordinate generated persistence artifacts and project configuration changes.

## Documentation Cleanup

The README was significantly reduced and cleaned up by removing outdated example material. The resulting documentation is more focused on the current plugin behavior and avoids keeping stale usage examples in the main project documentation.

## Test Coverage

This branch adds a large set of unit tests covering datasource creation, namespace handling, architecture generation, Faces generation, form generation, GlassFish embedded setup, Jakarta validation API setup, Payara Micro setup, persistence generation, OpenAPI generation, datasource utilities, Maven project utilities, string utilities, HTTP helpers, and XML helpers.

The goal of this test expansion is to make the plugin safer to evolve by covering the main project-modification paths that the Maven goals execute.

## Validation

Validated locally with:
```bash
./mvnw.cmd package
```
Result:

- Build successful
- Tests run: 146
- Failures: 0
- Errors: 0
- Skipped: 0

## Review Notes

GitHub reports that `develop` is 11 commits ahead of `main` and 17 commits behind `main`, so the branches have diverged. Reviewers should account for the existing `main` commits before merging and confirm whether `develop` should be updated/rebased first or merged as-is through this PR.
